### PR TITLE
Add a coloured, compact formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,33 @@ resolution in UTC.
 
 
 
+## type ColorFormatter
+``` go
+type ColorFormatter struct{}
+```
+ColorFormatter provides a compact formatter with colored output, ideal for terminals
+
+
+
+
+
+
+
+
+
+
+
+### func (\*ColorFormatter) Format
+``` go
+func (*ColorFormatter) Format(level Level, module, filename string, line int, timestamp time.Time, message string) string
+```
+Format returns the parameters separated by spaces except for filename and
+line which are separated by a colon.  The time is shown to second
+resolution in UTC.
+
+
+
+
 ## type Formatter
 ``` go
 type Formatter interface {

--- a/color_formatter.go
+++ b/color_formatter.go
@@ -1,0 +1,34 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package loggo
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/fatih/color"
+)
+
+// ColorFormatter is a compact formatter with colored output, ideal for output expected to be
+// viewed in a terminal
+type ColorFormatter struct{}
+
+var levelStrs = map[Level]string{
+	TRACE:    color.New(color.FgWhite).SprintFunc()("trace"),
+	DEBUG:    color.New(color.FgGreen).SprintFunc()("debug"),
+	INFO:     color.New(color.FgBlue).SprintFunc()("info "),
+	WARNING:  color.New(color.FgYellow).SprintFunc()("warn "),
+	ERROR:    color.New(color.FgRed).SprintFunc()("error"),
+	CRITICAL: color.New(color.BgRed).SprintFunc()("critc"),
+}
+
+// Format returns the parameters separated by spaces except for filename and
+// line which are separated by a colon.  Only the time is shown to second resolution
+// to make the output compact.
+func (*ColorFormatter) Format(level Level, module string, filename string, line int, timestamp time.Time, message string) string {
+	ts := timestamp.In(time.UTC).Format("15:04:05")
+	filename = filepath.Base(filename)
+	return fmt.Sprintf("%s %s %s %s:%d %s", ts, levelStrs[level], module, filename, line, message)
+}

--- a/color_formatter_test.go
+++ b/color_formatter_test.go
@@ -1,0 +1,25 @@
+// Copyright 2014 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package loggo_test
+
+import (
+	"time"
+
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/loggo"
+)
+
+type colorFormatterSuite struct{}
+
+var _ = gc.Suite(&colorFormatterSuite{})
+
+func (*colorFormatterSuite) TestColorFormat(c *gc.C) {
+	location, err := time.LoadLocation("UTC")
+	c.Assert(err, gc.IsNil)
+	testTime := time.Date(2013, 5, 3, 10, 53, 24, 123456, location)
+	colorFormatter := &loggo.ColorFormatter{}
+	colorFormatted := colorFormatter.Format(loggo.WARNING, "test.module", "some/deep/filename", 42, testTime, "hello world!")
+	c.Assert(colorFormatted, gc.Equals, "10:53:24 \x1b[33mwarn \x1b[0m test.module filename:42 hello world!")
+}

--- a/example/first.go
+++ b/example/first.go
@@ -22,6 +22,10 @@ func FirstInfo(message string) {
 	first.Infof(message)
 }
 
+func FirstDebug(message string) {
+	first.Debugf(message)
+}
+
 func FirstTrace(message string) {
 	first.Tracef(message)
 }

--- a/example/main.go
+++ b/example/main.go
@@ -30,6 +30,8 @@ func main() {
 	FirstInfo("first info")
 	FirstTrace("first trace")
 
+	loggo.ReplaceDefaultWriter(loggo.NewSimpleWriter(os.Stderr, &loggo.ColorFormatter{}))
+
 	SecondCritical("first critical")
 	SecondError("first error")
 	SecondWarning("first warning")

--- a/example/main.go
+++ b/example/main.go
@@ -28,14 +28,16 @@ func main() {
 	FirstError("first error")
 	FirstWarning("first warning")
 	FirstInfo("first info")
+	FirstDebug("first debug")
 	FirstTrace("first trace")
 
 	loggo.ReplaceDefaultWriter(loggo.NewSimpleWriter(os.Stderr, &loggo.ColorFormatter{}))
 
-	SecondCritical("first critical")
-	SecondError("first error")
-	SecondWarning("first warning")
-	SecondInfo("first info")
-	SecondTrace("first trace")
+	SecondCritical("second critical")
+	SecondError("second error")
+	SecondWarning("second warning")
+	SecondInfo("second info")
+	SecondDebug("second debug")
+	SecondTrace("second trace")
 
 }

--- a/example/second.go
+++ b/example/second.go
@@ -22,6 +22,9 @@ func SecondInfo(message string) {
 	second.Infof(message)
 }
 
+func SecondDebug(message string) {
+	second.Debugf(message)
+}
 func SecondTrace(message string) {
 	second.Tracef(message)
 }


### PR DESCRIPTION
Love loggo but it's a bit verbose during debugging programs locally, so this adds a `ColorFormatter` that:
 1. Makes the output compact (time & level)
 2. Adds a splash of colour

It looks like:

![image](https://cloud.githubusercontent.com/assets/1512227/12371918/47475fb4-bc3c-11e5-880b-b419eba1e502.png)

In my app, I check if it's connected to a terminal on startup using `golang.org/x/crypto/ssh/terminal`'s `terminal.IsTerminal()` and then either use `DefaultFormatter` or `ColorFormatter`. I think that's a nice feature but didn't know if it's desirable inside loggo, so I left it out for now. If it is, let me know and I can add it.

Naming-wise, I went for simple, open to suggestions.

Cheers!