### PR TITLE
Refactor Logger into SubLogger.

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,6 +11,9 @@ import (
 
 // LoggerConfig holds the configuration for a single logger.
 type LoggerConfig struct {
+	// Name is the logger's name.
+	Name string
+
 	// Level is the log level that should be used by the logger.
 	Level Level
 }
@@ -26,6 +29,9 @@ func ParseLoggerConfig(spec string) (LoggerConfig, error) {
 		return cfg, fmt.Errorf("logger config is blank")
 	}
 
+	// TODO(ericsnow) Get the name.  We need to sort out backward
+	// compability first.
+
 	levelStr := spec // For now level is the only thing in the spec.
 	level, ok := ParseLevel(levelStr)
 	if !ok {
@@ -39,6 +45,8 @@ func ParseLoggerConfig(spec string) (LoggerConfig, error) {
 // String returns a logger configuration string that may be parsed
 // using ParseLoggerConfig or ParseLoggersConfig().
 func (cfg LoggerConfig) String() string {
+	// TODO(ericsnow) Include the name.  We need to sort out backward
+	// compability first.
 	return fmt.Sprintf("%s", cfg.Level)
 }
 
@@ -51,9 +59,9 @@ func (configs LoggersConfig) String() string {
 	// output in alphabetical order.
 	names := []string{}
 	for name := range configs {
-		if name == rootName {
+		if name == rootModuleName {
 			// This could potentially result in a duplicate entry...
-			name = rootString
+			name = rootName
 		}
 		names = append(names, name)
 	}
@@ -99,7 +107,7 @@ func ParseLoggersConfig(spec string) (LoggersConfig, error) {
 		if err != nil {
 			return nil, err
 		}
-		return LoggersConfig{rootName: cfg}, nil
+		return LoggersConfig{rootModuleName: cfg}, nil
 	}
 
 	configs := make(LoggersConfig)
@@ -120,14 +128,14 @@ func parseConfigEntry(entry string) (string, LoggerConfig, error) {
 	if len(pair) < 2 {
 		return "", cfg, fmt.Errorf("logger entry expected '=', found %q", entry)
 	}
-	name, spec := rootName, entry
+	name, spec := rootModuleName, entry
 	if len(pair) == 2 {
 		name, spec = strings.TrimSpace(pair[0]), strings.TrimSpace(pair[1])
 		if name == "" {
 			return "", cfg, fmt.Errorf("logger entry %q has blank name", entry)
 		}
-		if name == rootString {
-			name = rootName
+		if name == rootName {
+			name = rootModuleName
 		}
 	}
 	if spec == "" {

--- a/formatter.go
+++ b/formatter.go
@@ -12,7 +12,7 @@ import (
 // Formatter defines the single method Format, which takes the logging
 // information, and converts it to a string.
 type Formatter interface {
-	Format(level Level, module, filename string, line int, timestamp time.Time, message string) string
+	Format(level Level, loggerName, filename string, line int, timestamp time.Time, message string) string
 }
 
 // DefaultFormatter provides a simple concatenation of all the components.
@@ -21,9 +21,9 @@ type DefaultFormatter struct{}
 // Format returns the parameters separated by spaces except for filename and
 // line which are separated by a colon.  The timestamp is shown to second
 // resolution in UTC.
-func (*DefaultFormatter) Format(level Level, module, filename string, line int, timestamp time.Time, message string) string {
+func (*DefaultFormatter) Format(level Level, loggerName, filename string, line int, timestamp time.Time, message string) string {
 	ts := timestamp.In(time.UTC).Format("2006-01-02 15:04:05")
 	// Just get the basename from the filename
 	filename = filepath.Base(filename)
-	return fmt.Sprintf("%s %s %s %s:%d %s", ts, level, module, filename, line, message)
+	return fmt.Sprintf("%s %s %s %s:%d %s", ts, level, loggerName, filename, line, message)
 }

--- a/global.go
+++ b/global.go
@@ -29,6 +29,11 @@ func LoggerInfo() string {
 	return globalLoggers.Config().String()
 }
 
+// Root returns the root logger.
+func Root() SubLogger {
+	return globalLoggers.Root()
+}
+
 // GetLogger returns a logger for the given module name,
 // creating it and its parents if necessary.
 func GetLogger(name string) SubLogger {

--- a/global.go
+++ b/global.go
@@ -29,9 +29,9 @@ func LoggerInfo() string {
 	return globalLoggers.Config().String()
 }
 
-// GetLogger returns a Logger for the given module name,
+// GetLogger returns a logger for the given module name,
 // creating it and its parents if necessary.
-func GetLogger(name string) Logger {
+func GetLogger(name string) SubLogger {
 	return globalLoggers.Get(name)
 }
 

--- a/global_test.go
+++ b/global_test.go
@@ -22,7 +22,7 @@ func (*GlobalLoggersSuite) SetUpTest(c *gc.C) {
 }
 
 func (*GlobalLoggersSuite) TestRootLogger(c *gc.C) {
-	var root loggo.Logger
+	var root loggo.SubLogger
 
 	got := loggo.GetLogger("")
 
@@ -175,18 +175,18 @@ func (s *GlobalLoggersSuite) TestConfigureLoggers(c *gc.C) {
 		// Test that it's idempotent.
 		err = loggo.ConfigureLoggers(test.spec)
 		c.Assert(err, gc.IsNil)
-		c.Assert(loggo.LoggerInfo(), gc.Equals, test.info)
+		c.Check(loggo.LoggerInfo(), gc.Equals, test.info)
 
 		// Test that calling ConfigureLoggers with the
 		// output of LoggerInfo works too.
 		err = loggo.ConfigureLoggers(test.info)
 		c.Assert(err, gc.IsNil)
-		c.Assert(loggo.LoggerInfo(), gc.Equals, test.info)
+		c.Check(loggo.LoggerInfo(), gc.Equals, test.info)
 	}
 }
 
 type GlobalWritersSuite struct {
-	logger loggo.Logger
+	logger loggo.SubLogger
 	writer *loggotest.Writer
 }
 
@@ -320,7 +320,7 @@ func (s *GlobalWritersSuite) TestWillWrite(c *gc.C) {
 }
 
 type GlobalBenchmarksSuite struct {
-	logger loggo.Logger
+	logger loggo.SubLogger
 	writer *loggotest.Writer
 }
 

--- a/level.go
+++ b/level.go
@@ -111,7 +111,7 @@ func EffectiveMinLevel(leveler HasMinLevel) Level {
 	if level == UNSPECIFIED {
 		// Get the level from the parent, if there is one.
 		leveler, ok := leveler.(HasParentWithMinLevel)
-		if ok {
+		if ok && leveler != nil {
 			if parent := leveler.ParentWithMinLogLevel(); parent != nil {
 				// We might consider guarding against cycles here...
 				level = EffectiveMinLevel(parent)

--- a/logger.go
+++ b/logger.go
@@ -90,19 +90,8 @@ func (logger Logger) LogLevel() Level {
 	return logger.getModule().MinLogLevel()
 }
 
-// EffectiveLogLevel returns the effective min log level of
-// the receiver - that is, messages with a lesser severity
-// level will be discarded.
-//
-// If the log level of the receiver is unspecified,
-// it will be taken from the effective log level of its
-// parent.
-func (logger Logger) EffectiveLogLevel() Level {
-	return EffectiveMinLevel(logger.getModule())
-}
-
-// Config returns the current configuration for the Logger.
-func (logger Logger) Config() LoggerConfig {
+// config returns the current configuration for the Logger.
+func (logger Logger) config() LoggerConfig {
 	cfg := logger.getModule().config()
 	logger.updateConfig(&cfg)
 	return cfg
@@ -113,8 +102,8 @@ func (logger Logger) updateConfig(cfg *LoggerConfig) {
 	// For now there isn't any logger-specific info.
 }
 
-// ApplyConfig configures the logger according to the provided config.
-func (logger Logger) ApplyConfig(cfg LoggerConfig) {
+// applyConfig configures the logger according to the provided config.
+func (logger Logger) applyConfig(cfg LoggerConfig) {
 	logger.getModule().applyConfig(cfg)
 }
 
@@ -213,6 +202,20 @@ func (logger Logger) Debugf(message string, args ...interface{}) {
 // Tracef logs the printf-formatted message at trace level.
 func (logger Logger) Tracef(message string, args ...interface{}) {
 	logger.Logf(TRACE, message, args...)
+}
+
+// TODO(ericsnow) Everything below here is unnecessary now and should
+// be deprecated.
+
+// EffectiveLogLevel returns the effective min log level of
+// the receiver - that is, messages with a lesser severity
+// level will be discarded.
+//
+// If the log level of the receiver is unspecified,
+// it will be taken from the effective log level of its
+// parent.
+func (logger Logger) EffectiveLogLevel() Level {
+	return EffectiveMinLevel(logger.getModule())
 }
 
 // IsLevelEnabled returns whether debugging is enabled

--- a/logger.go
+++ b/logger.go
@@ -245,3 +245,25 @@ func (logger logger) Debugf(message string, args ...interface{}) {
 func (logger logger) Tracef(message string, args ...interface{}) {
 	logger.Logf(TRACE, message, args...)
 }
+
+// IOAdapter is an io.Writer that logs written messages.
+type IOAdapter struct {
+	logger Logger
+	level  Level
+}
+
+// LoggerAsIOWriter returns a new io.Writer that logs the written messages
+// at the given log level.
+func LoggerAsIOWriter(logger Logger, level Level) *IOAdapter {
+	return &IOAdapter{
+		logger: logger,
+		level:  level,
+	}
+}
+
+// Write implements io.Writer, logging the message at the predefined log level.
+func (w IOAdapter) Write(msg []byte) (int, error) {
+	n := len(msg)
+	w.logger.LogCallf(2, w.level, string(msg))
+	return n, nil
+}

--- a/logger.go
+++ b/logger.go
@@ -5,6 +5,7 @@ package loggo
 
 import (
 	"fmt"
+	"log"
 	"runtime"
 	"time"
 )
@@ -244,6 +245,13 @@ func (logger logger) Debugf(message string, args ...interface{}) {
 // Tracef logs the printf-formatted message at trace level.
 func (logger logger) Tracef(message string, args ...interface{}) {
 	logger.Logf(TRACE, message, args...)
+}
+
+// LoggerAsGoLogger wraps the logger in a stdlib log.Logger. The
+// messages are logged at the provided level.
+func LoggerAsGoLogger(logger Logger, level Level) *log.Logger {
+	w := LoggerAsIOWriter(logger, level)
+	return log.New(w, "", 0)
 }
 
 // IOAdapter is an io.Writer that logs written messages.

--- a/logger_test.go
+++ b/logger_test.go
@@ -331,6 +331,20 @@ func (s *LoggerSuite) TestMultipleWriters(c *gc.C) {
 	c.Assert(traceWriter.Log(), gc.HasLen, 4)
 }
 
+func (s *LoggerSuite) TestLoggerAsGoLogger(c *gc.C) {
+	writer := &loggotest.Writer{}
+	logger := loggo.NewLogger(loggo.NewMinLevelWriter(writer, loggo.TRACE))
+	logger.SetLogLevel(loggo.TRACE)
+	log := loggo.LoggerAsGoLogger(logger, loggo.WARNING)
+
+	log.Print("raw message")
+
+	records := writer.Log()
+	c.Assert(records, gc.HasLen, 1)
+	c.Assert(records[0].Level, gc.Equals, loggo.WARNING)
+	c.Assert(records[0].Message, gc.Equals, "raw message")
+}
+
 func (s *LoggerSuite) TestLoggerAsIOWriter(c *gc.C) {
 	writer := &loggotest.Writer{}
 	logger := loggo.NewLogger(loggo.NewMinLevelWriter(writer, loggo.TRACE))

--- a/logger_test.go
+++ b/logger_test.go
@@ -342,6 +342,8 @@ func (s *LoggerSuite) TestLoggerAsGoLogger(c *gc.C) {
 	records := writer.Log()
 	c.Assert(records, gc.HasLen, 1)
 	c.Assert(records[0].Level, gc.Equals, loggo.WARNING)
+	c.Assert(records[0].Module, gc.Equals, "<>")
+	c.Assert(records[0].Filename, gc.Equals, "logger_test.go")
 	c.Assert(records[0].Message, gc.Equals, "raw message")
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -28,132 +28,68 @@ func (s *LoggerSuite) TearDownSuite(c *gc.C) {
 	loggo.ResetLoggers()
 }
 
-func (s *LoggerSuite) TestRootLogger(c *gc.C) {
-	root := loggo.Logger{}
-	c.Check(root.Name(), gc.Equals, "<root>")
-	c.Assert(root.IsErrorEnabled(), gc.Equals, true)
-	c.Assert(root.IsWarningEnabled(), gc.Equals, true)
-	c.Assert(root.IsInfoEnabled(), gc.Equals, false)
-	c.Assert(root.IsDebugEnabled(), gc.Equals, false)
-	c.Assert(root.IsTraceEnabled(), gc.Equals, false)
-}
-
-func (s *LoggerSuite) TestModuleName(c *gc.C) {
-	var parent loggo.Logger
-	logger, _ := loggo.NewLogger("loggo.testing", parent)
-	c.Assert(logger.Name(), gc.Equals, "loggo.testing")
-}
-
 func (s *LoggerSuite) TestSetLevel(c *gc.C) {
-	var parent loggo.Logger
-	logger, _ := loggo.NewLogger("testing", parent)
+	logger := loggo.NewLogger(nil)
 
-	c.Assert(logger.LogLevel(), gc.Equals, loggo.UNSPECIFIED)
-	c.Assert(logger.EffectiveLogLevel(), gc.Equals, loggo.WARNING)
-	c.Assert(logger.IsErrorEnabled(), gc.Equals, true)
-	c.Assert(logger.IsWarningEnabled(), gc.Equals, true)
-	c.Assert(logger.IsInfoEnabled(), gc.Equals, false)
-	c.Assert(logger.IsDebugEnabled(), gc.Equals, false)
-	c.Assert(logger.IsTraceEnabled(), gc.Equals, false)
+	c.Assert(logger.MinLogLevel(), gc.Equals, loggo.UNSPECIFIED)
+	c.Assert(loggo.EffectiveMinLevel(logger), gc.Equals, loggo.UNSPECIFIED)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.ERROR), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.WARNING), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.INFO), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.DEBUG), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.TRACE), gc.Equals, true)
 	logger.SetLogLevel(loggo.TRACE)
-	c.Assert(logger.LogLevel(), gc.Equals, loggo.TRACE)
-	c.Assert(logger.EffectiveLogLevel(), gc.Equals, loggo.TRACE)
-	c.Assert(logger.IsErrorEnabled(), gc.Equals, true)
-	c.Assert(logger.IsWarningEnabled(), gc.Equals, true)
-	c.Assert(logger.IsInfoEnabled(), gc.Equals, true)
-	c.Assert(logger.IsDebugEnabled(), gc.Equals, true)
-	c.Assert(logger.IsTraceEnabled(), gc.Equals, true)
+	c.Assert(logger.MinLogLevel(), gc.Equals, loggo.TRACE)
+	c.Assert(loggo.EffectiveMinLevel(logger), gc.Equals, loggo.TRACE)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.ERROR), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.WARNING), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.INFO), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.DEBUG), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.TRACE), gc.Equals, true)
 	logger.SetLogLevel(loggo.DEBUG)
-	c.Assert(logger.LogLevel(), gc.Equals, loggo.DEBUG)
-	c.Assert(logger.EffectiveLogLevel(), gc.Equals, loggo.DEBUG)
-	c.Assert(logger.IsErrorEnabled(), gc.Equals, true)
-	c.Assert(logger.IsWarningEnabled(), gc.Equals, true)
-	c.Assert(logger.IsInfoEnabled(), gc.Equals, true)
-	c.Assert(logger.IsDebugEnabled(), gc.Equals, true)
-	c.Assert(logger.IsTraceEnabled(), gc.Equals, false)
+	c.Assert(logger.MinLogLevel(), gc.Equals, loggo.DEBUG)
+	c.Assert(loggo.EffectiveMinLevel(logger), gc.Equals, loggo.DEBUG)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.ERROR), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.WARNING), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.INFO), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.DEBUG), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.TRACE), gc.Equals, false)
 	logger.SetLogLevel(loggo.INFO)
-	c.Assert(logger.LogLevel(), gc.Equals, loggo.INFO)
-	c.Assert(logger.EffectiveLogLevel(), gc.Equals, loggo.INFO)
-	c.Assert(logger.IsErrorEnabled(), gc.Equals, true)
-	c.Assert(logger.IsWarningEnabled(), gc.Equals, true)
-	c.Assert(logger.IsInfoEnabled(), gc.Equals, true)
-	c.Assert(logger.IsDebugEnabled(), gc.Equals, false)
-	c.Assert(logger.IsTraceEnabled(), gc.Equals, false)
+	c.Assert(logger.MinLogLevel(), gc.Equals, loggo.INFO)
+	c.Assert(loggo.EffectiveMinLevel(logger), gc.Equals, loggo.INFO)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.ERROR), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.WARNING), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.INFO), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.DEBUG), gc.Equals, false)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.TRACE), gc.Equals, false)
 	logger.SetLogLevel(loggo.WARNING)
-	c.Assert(logger.LogLevel(), gc.Equals, loggo.WARNING)
-	c.Assert(logger.EffectiveLogLevel(), gc.Equals, loggo.WARNING)
-	c.Assert(logger.IsErrorEnabled(), gc.Equals, true)
-	c.Assert(logger.IsWarningEnabled(), gc.Equals, true)
-	c.Assert(logger.IsInfoEnabled(), gc.Equals, false)
-	c.Assert(logger.IsDebugEnabled(), gc.Equals, false)
-	c.Assert(logger.IsTraceEnabled(), gc.Equals, false)
+	c.Assert(logger.MinLogLevel(), gc.Equals, loggo.WARNING)
+	c.Assert(loggo.EffectiveMinLevel(logger), gc.Equals, loggo.WARNING)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.ERROR), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.WARNING), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.INFO), gc.Equals, false)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.DEBUG), gc.Equals, false)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.TRACE), gc.Equals, false)
 	logger.SetLogLevel(loggo.ERROR)
-	c.Assert(logger.LogLevel(), gc.Equals, loggo.ERROR)
-	c.Assert(logger.EffectiveLogLevel(), gc.Equals, loggo.ERROR)
-	c.Assert(logger.IsErrorEnabled(), gc.Equals, true)
-	c.Assert(logger.IsWarningEnabled(), gc.Equals, false)
-	c.Assert(logger.IsInfoEnabled(), gc.Equals, false)
-	c.Assert(logger.IsDebugEnabled(), gc.Equals, false)
-	c.Assert(logger.IsTraceEnabled(), gc.Equals, false)
+	c.Assert(logger.MinLogLevel(), gc.Equals, loggo.ERROR)
+	c.Assert(loggo.EffectiveMinLevel(logger), gc.Equals, loggo.ERROR)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.ERROR), gc.Equals, true)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.WARNING), gc.Equals, false)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.INFO), gc.Equals, false)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.DEBUG), gc.Equals, false)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.TRACE), gc.Equals, false)
 	// This is added for completeness, but not really expected to be used.
 	logger.SetLogLevel(loggo.CRITICAL)
-	c.Assert(logger.LogLevel(), gc.Equals, loggo.CRITICAL)
-	c.Assert(logger.EffectiveLogLevel(), gc.Equals, loggo.CRITICAL)
-	c.Assert(logger.IsErrorEnabled(), gc.Equals, false)
-	c.Assert(logger.IsWarningEnabled(), gc.Equals, false)
-	c.Assert(logger.IsInfoEnabled(), gc.Equals, false)
-	c.Assert(logger.IsDebugEnabled(), gc.Equals, false)
-	c.Assert(logger.IsTraceEnabled(), gc.Equals, false)
+	c.Assert(logger.MinLogLevel(), gc.Equals, loggo.CRITICAL)
+	c.Assert(loggo.EffectiveMinLevel(logger), gc.Equals, loggo.CRITICAL)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.ERROR), gc.Equals, false)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.WARNING), gc.Equals, false)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.INFO), gc.Equals, false)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.DEBUG), gc.Equals, false)
+	c.Assert(loggo.IsLevelEnabled(logger, loggo.TRACE), gc.Equals, false)
 	logger.SetLogLevel(loggo.UNSPECIFIED)
-	c.Assert(logger.LogLevel(), gc.Equals, loggo.UNSPECIFIED)
-	c.Assert(logger.EffectiveLogLevel(), gc.Equals, loggo.WARNING)
-}
-
-func (s *LoggerSuite) TestModuleLowered(c *gc.C) {
-	var parent loggo.Logger
-	logger1, _ := loggo.NewLogger("TESTING.MODULE", parent)
-	logger2, _ := loggo.NewLogger("Testing", parent)
-
-	c.Assert(logger1.Name(), gc.Equals, "testing.module")
-	c.Assert(logger2.Name(), gc.Equals, "testing")
-}
-
-func (s *LoggerSuite) TestLevelsInherited(c *gc.C) {
-	root, _ := loggo.NewRootLogger()
-	first, _ := loggo.NewLogger("first", root)
-	second, _ := loggo.NewLogger("first.second", first)
-
-	root.SetLogLevel(loggo.ERROR)
-	c.Assert(root.LogLevel(), gc.Equals, loggo.ERROR)
-	c.Assert(root.EffectiveLogLevel(), gc.Equals, loggo.ERROR)
-	c.Assert(first.LogLevel(), gc.Equals, loggo.UNSPECIFIED)
-	c.Assert(first.EffectiveLogLevel(), gc.Equals, loggo.ERROR)
-	c.Assert(second.LogLevel(), gc.Equals, loggo.UNSPECIFIED)
-	c.Assert(second.EffectiveLogLevel(), gc.Equals, loggo.ERROR)
-
-	first.SetLogLevel(loggo.DEBUG)
-	c.Assert(root.LogLevel(), gc.Equals, loggo.ERROR)
-	c.Assert(root.EffectiveLogLevel(), gc.Equals, loggo.ERROR)
-	c.Assert(first.LogLevel(), gc.Equals, loggo.DEBUG)
-	c.Assert(first.EffectiveLogLevel(), gc.Equals, loggo.DEBUG)
-	c.Assert(second.LogLevel(), gc.Equals, loggo.UNSPECIFIED)
-	c.Assert(second.EffectiveLogLevel(), gc.Equals, loggo.DEBUG)
-
-	second.SetLogLevel(loggo.INFO)
-	c.Assert(root.LogLevel(), gc.Equals, loggo.ERROR)
-	c.Assert(root.EffectiveLogLevel(), gc.Equals, loggo.ERROR)
-	c.Assert(first.LogLevel(), gc.Equals, loggo.DEBUG)
-	c.Assert(first.EffectiveLogLevel(), gc.Equals, loggo.DEBUG)
-	c.Assert(second.LogLevel(), gc.Equals, loggo.INFO)
-	c.Assert(second.EffectiveLogLevel(), gc.Equals, loggo.INFO)
-
-	first.SetLogLevel(loggo.UNSPECIFIED)
-	c.Assert(root.LogLevel(), gc.Equals, loggo.ERROR)
-	c.Assert(root.EffectiveLogLevel(), gc.Equals, loggo.ERROR)
-	c.Assert(first.LogLevel(), gc.Equals, loggo.UNSPECIFIED)
-	c.Assert(first.EffectiveLogLevel(), gc.Equals, loggo.ERROR)
-	c.Assert(second.LogLevel(), gc.Equals, loggo.INFO)
-	c.Assert(second.EffectiveLogLevel(), gc.Equals, loggo.INFO)
+	c.Assert(logger.MinLogLevel(), gc.Equals, loggo.UNSPECIFIED)
+	c.Assert(loggo.EffectiveMinLevel(logger), gc.Equals, loggo.UNSPECIFIED)
 }
 
 func (s *LoggerSuite) TestLoggingStrings(c *gc.C) {
@@ -289,7 +225,7 @@ func (s *LoggerSuite) TestNoWriters(c *gc.C) {
 	err := loggo.RegisterWriter("test", writer, loggo.TRACE)
 	c.Assert(err, gc.IsNil)
 	// Use a non-global logger with no writers set.
-	logger, _ := loggo.NewRootLogger()
+	logger := loggo.NewLogger(nil)
 	logger.SetLogLevel(loggo.TRACE)
 
 	logger.Warningf("just a simple warning")
@@ -298,7 +234,8 @@ func (s *LoggerSuite) TestNoWriters(c *gc.C) {
 }
 
 func (s *LoggerSuite) TestWritingLimitWarning(c *gc.C) {
-	logger, writers := loggo.NewRootLogger()
+	writers := loggo.NewWriters(nil)
+	logger := loggo.NewLogger(writers)
 	logger.SetLogLevel(loggo.TRACE)
 	writer := &loggotest.Writer{}
 	err := writers.AddWithLevel("test", writer, loggo.WARNING)
@@ -328,7 +265,8 @@ func (s *LoggerSuite) TestWritingLimitWarning(c *gc.C) {
 }
 
 func (s *LoggerSuite) TestWritingLimitTrace(c *gc.C) {
-	logger, writers := loggo.NewRootLogger()
+	writers := loggo.NewWriters(nil)
+	logger := loggo.NewLogger(writers)
 	logger.SetLogLevel(loggo.TRACE)
 	writer := &loggotest.Writer{}
 	err := writers.AddWithLevel("test", writer, loggo.TRACE)
@@ -366,7 +304,8 @@ func (s *LoggerSuite) TestWritingLimitTrace(c *gc.C) {
 }
 
 func (s *LoggerSuite) TestMultipleWriters(c *gc.C) {
-	logger, writers := loggo.NewRootLogger()
+	writers := loggo.NewWriters(nil)
+	logger := loggo.NewLogger(writers)
 	logger.SetLogLevel(loggo.TRACE)
 	errorWriter := &loggotest.Writer{}
 	err := writers.AddWithLevel("error", errorWriter, loggo.ERROR)

--- a/loggers.go
+++ b/loggers.go
@@ -30,28 +30,25 @@ func LoggersFromConfig(spec string, writers *Writers) (*Loggers, error) {
 	}
 	loggers.ApplyConfig(configs)
 
-	loggers.m.rootLevel = loggers.Get(rootName).LogLevel()
+	loggers.m.rootLevel = loggers.Get(rootName).MinLogLevel()
 	return loggers, nil
 }
 
-// Get returns a Logger for the given module name, creating it and
+// Get returns a logger for the given module name, creating it and
 // its parents if necessary.
-func (ls *Loggers) Get(name string) Logger {
-	return Logger{
-		impl:   ls.m.get(name),
-		writer: ls.w,
+func (ls *Loggers) Get(name string) SubLogger {
+	return SubLogger{
+		logger: logger{
+			loggerState: ls.m.get(name),
+			writer:      ls.w,
+		},
 	}
 }
 
 // Config returns the current configuration of the Loggers. Loggers
 // with UNSPECIFIED level will not be included.
 func (ls *Loggers) Config() LoggersConfig {
-	configs := ls.m.config()
-	for name, cfg := range configs {
-		ls.Get(name).updateConfig(&cfg)
-		configs[name] = cfg
-	}
-	return configs
+	return ls.m.config()
 }
 
 // ApplyConfig configures the loggers according to the provided configs.

--- a/loggers.go
+++ b/loggers.go
@@ -30,8 +30,13 @@ func LoggersFromConfig(spec string, writers *Writers) (*Loggers, error) {
 	}
 	loggers.ApplyConfig(configs)
 
-	loggers.m.rootLevel = loggers.Get(rootName).MinLogLevel()
+	loggers.m.rootLevel = loggers.Root().MinLogLevel()
 	return loggers, nil
+}
+
+// Root returns the root logger.
+func (ls *Loggers) Root() SubLogger {
+	return ls.Get(rootName)
 }
 
 // Get returns a logger for the given module name, creating it and

--- a/loggers.go
+++ b/loggers.go
@@ -58,7 +58,7 @@ func (ls *Loggers) Config() LoggersConfig {
 func (ls *Loggers) ApplyConfig(configs LoggersConfig) {
 	for name, cfg := range configs {
 		logger := ls.Get(name)
-		logger.ApplyConfig(cfg)
+		logger.applyConfig(cfg)
 	}
 }
 

--- a/loggers.go
+++ b/loggers.go
@@ -42,12 +42,7 @@ func (ls *Loggers) Root() SubLogger {
 // Get returns a logger for the given module name, creating it and
 // its parents if necessary.
 func (ls *Loggers) Get(name string) SubLogger {
-	return SubLogger{
-		logger: logger{
-			loggerState: ls.m.get(name),
-			writer:      ls.w,
-		},
-	}
+	return newSubLogger(ls.m.get(name), ls.w)
 }
 
 // Config returns the current configuration of the Loggers. Loggers

--- a/loggotest/logger.go
+++ b/loggotest/logger.go
@@ -7,15 +7,20 @@ import (
 	"github.com/juju/loggo"
 )
 
-// TraceLogger returns the named logger. It also sets the logger's
+// Logger returns the named logger. It also sets the logger's
 // writer and returns it.
-func TraceLogger() (loggo.SubLogger, *Writer) {
-	logger, writers := loggo.NewRootLogger()
+func Logger(level loggo.Level) (loggo.ConfigurableLogger, *Writer) {
+	writer := &Writer{}
+
+	logger := loggo.NewLogger(loggo.NewMinLevelWriter(writer, level))
 	// Make it so the logger itself writes all messages.
 	logger.SetLogLevel(loggo.TRACE)
 
-	writer := &Writer{}
-	writers.AddWithLevel("", writer, loggo.TRACE)
-
 	return logger, writer
+}
+
+// TraceLogger returns the named logger. It also sets the logger's
+// writer and returns it.
+func TraceLogger() (loggo.ConfigurableLogger, *Writer) {
+	return Logger(loggo.TRACE)
 }

--- a/loggotest/logger.go
+++ b/loggotest/logger.go
@@ -9,7 +9,7 @@ import (
 
 // TraceLogger returns the named logger. It also sets the logger's
 // writer and returns it.
-func TraceLogger() (loggo.Logger, *Writer) {
+func TraceLogger() (loggo.SubLogger, *Writer) {
 	logger, writers := loggo.NewRootLogger()
 	// Make it so the logger itself writes all messages.
 	logger.SetLogLevel(loggo.TRACE)

--- a/sublogger.go
+++ b/sublogger.go
@@ -1,0 +1,133 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package loggo
+
+import (
+	"reflect"
+)
+
+// A SubLogger represents a logging module. It has an associated logging
+// level which can be changed; messages of lesser severity will
+// be dropped. SubLoggers have a hierarchical relationship - see
+// the package documentation.
+//
+// The zero SubLogger value is usable - any messages logged
+// to it will be sent to the global root logger.
+type SubLogger struct {
+	logger
+}
+
+// NewRootLogger creates a root logger and returns it, along with
+// the writers that the logger will use.
+func NewRootLogger() (SubLogger, *Writers) {
+	writers := NewWriters(nil) // starts off empty
+	root := SubLogger{
+		logger: logger{
+			loggerState: newRootModule(),
+			writer:      writers,
+		},
+	}
+	return root, writers
+}
+
+// NewSubLogger creates a new SubLogger with the given name and parent.
+// The logger uses the name to identify itself. The parent is used when
+// determining the effective log level. The new logger is returned,
+// along with the writers the logger will use.
+func NewSubLogger(name string, parent SubLogger) (SubLogger, *Writers) {
+	var writers *Writers
+	if parent.isZero() {
+		parent, writers = NewRootLogger()
+	} else {
+		writers = NewWriters(nil) // starts off empty
+		if parent.writer != nil {
+			// We set the level as low as possible in order to defer
+			// strictly to the new logger's level.
+			// TODO(ericsnow) Use parent.writer's level.
+			writers.AddWithLevel(defaultWriterName, parent.writer, UNSPECIFIED)
+		}
+	}
+	logger := newSubLogger(name, parent.loggerState, writers)
+	return logger, writers
+}
+
+func newSubLogger(name string, parent *loggerState, writer MinLevelWriter) SubLogger {
+	// The parent *may* be nil.
+	return SubLogger{
+		logger: logger{
+			loggerState: newSubmodule(name, parent, defaultLevel),
+			writer:      writer,
+		},
+	}
+}
+
+func (logger SubLogger) isZero() bool {
+	return reflect.DeepEqual(logger, SubLogger{})
+}
+
+// Name returns the logger's module name.
+func (logger SubLogger) Name() string {
+	if logger.logger.Name() == rootModuleName {
+		return rootName
+	}
+	return logger.logger.Name()
+}
+
+// TODO(ericsnow) Everything below here is unnecessary now and should
+// be deprecated.
+
+// LogLevel returns the configured min log level of the logger.
+//
+// This is strictly an alias for MinLogLevel, intended to align with
+// a more commonly used (but less specific) name.
+func (logger SubLogger) LogLevel() Level {
+	return logger.MinLogLevel()
+}
+
+// EffectiveLogLevel returns the effective min log level of
+// the receiver - that is, messages with a lesser severity
+// level will be discarded.
+//
+// If the log level of the receiver is unspecified,
+// it will be taken from the effective log level of its
+// parent.
+func (logger SubLogger) EffectiveLogLevel() Level {
+	return EffectiveMinLevel(logger)
+}
+
+// IsLevelEnabled returns whether debugging is enabled
+// for the given log level.
+func (logger SubLogger) IsLevelEnabled(level Level) bool {
+	return IsLevelEnabled(logger, level)
+}
+
+// IsErrorEnabled returns whether debugging is enabled
+// at error level.
+func (logger SubLogger) IsErrorEnabled() bool {
+	return logger.IsLevelEnabled(ERROR)
+}
+
+// IsWarningEnabled returns whether debugging is enabled
+// at warning level.
+func (logger SubLogger) IsWarningEnabled() bool {
+	return logger.IsLevelEnabled(WARNING)
+}
+
+// IsInfoEnabled returns whether debugging is enabled
+// at info level.
+func (logger SubLogger) IsInfoEnabled() bool {
+	return logger.IsLevelEnabled(INFO)
+}
+
+// IsDebugEnabled returns whether debugging is enabled
+// at debug level.
+func (logger SubLogger) IsDebugEnabled() bool {
+	return logger.IsLevelEnabled(DEBUG)
+}
+
+// IsTraceEnabled returns whether debugging is enabled
+// at trace level.
+func (logger SubLogger) IsTraceEnabled() bool {
+	return logger.IsLevelEnabled(TRACE)
+}

--- a/sublogger_test.go
+++ b/sublogger_test.go
@@ -1,0 +1,110 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package loggo_test
+
+import (
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/loggo"
+)
+
+type SubLoggerSuite struct{}
+
+var _ = gc.Suite(&SubLoggerSuite{})
+
+func (*SubLoggerSuite) SetUpTest(c *gc.C) {
+	loggo.ResetLoggers()
+}
+
+func (s *SubLoggerSuite) TearDownTest(c *gc.C) {
+	loggo.ResetWriters()
+}
+
+func (s *SubLoggerSuite) TearDownSuite(c *gc.C) {
+	loggo.ResetLoggers()
+}
+
+func (s *SubLoggerSuite) TestRootLogger(c *gc.C) {
+	root := loggo.SubLogger{}
+	c.Check(root.Name(), gc.Equals, "<root>")
+	c.Assert(root.IsErrorEnabled(), gc.Equals, true)
+	c.Assert(root.IsWarningEnabled(), gc.Equals, true)
+	c.Assert(root.IsInfoEnabled(), gc.Equals, false)
+	c.Assert(root.IsDebugEnabled(), gc.Equals, false)
+	c.Assert(root.IsTraceEnabled(), gc.Equals, false)
+}
+
+func (s *SubLoggerSuite) TestModuleName(c *gc.C) {
+	var parent loggo.SubLogger
+	logger, _ := loggo.NewSubLogger("loggo.testing", parent)
+	c.Assert(logger.Name(), gc.Equals, "loggo.testing")
+}
+
+func (s *SubLoggerSuite) TestModuleLowered(c *gc.C) {
+	var parent loggo.SubLogger
+	logger1, _ := loggo.NewSubLogger("TESTING.MODULE", parent)
+	logger2, _ := loggo.NewSubLogger("Testing", parent)
+
+	c.Assert(logger1.Name(), gc.Equals, "testing.module")
+	c.Assert(logger2.Name(), gc.Equals, "testing")
+}
+
+func (s *SubLoggerSuite) TestUnspecifiedLevel(c *gc.C) {
+	var parent loggo.SubLogger
+	logger, _ := loggo.NewSubLogger("...", parent)
+	c.Assert(logger.LogLevel(), gc.Equals, loggo.UNSPECIFIED)
+	c.Assert(logger.EffectiveLogLevel(), gc.Equals, loggo.WARNING)
+
+	logger.SetLogLevel(loggo.UNSPECIFIED)
+	c.Assert(logger.LogLevel(), gc.Equals, loggo.UNSPECIFIED)
+	c.Assert(logger.EffectiveLogLevel(), gc.Equals, loggo.WARNING)
+}
+
+func (s *SubLoggerSuite) TestRootUnspecifiedLevel(c *gc.C) {
+	logger, _ := loggo.NewRootLogger()
+	c.Assert(logger.LogLevel(), gc.Equals, loggo.WARNING)
+	c.Assert(logger.EffectiveLogLevel(), gc.Equals, loggo.WARNING)
+
+	logger.SetLogLevel(loggo.UNSPECIFIED)
+	c.Assert(logger.LogLevel(), gc.Equals, loggo.WARNING)
+	c.Assert(logger.EffectiveLogLevel(), gc.Equals, loggo.WARNING)
+}
+
+func (s *SubLoggerSuite) TestLevelsInherited(c *gc.C) {
+	root, _ := loggo.NewRootLogger()
+	first, _ := loggo.NewSubLogger("first", root)
+	second, _ := loggo.NewSubLogger("first.second", first)
+
+	root.SetLogLevel(loggo.ERROR)
+	c.Assert(root.LogLevel(), gc.Equals, loggo.ERROR)
+	c.Assert(root.EffectiveLogLevel(), gc.Equals, loggo.ERROR)
+	c.Assert(first.LogLevel(), gc.Equals, loggo.UNSPECIFIED)
+	c.Assert(first.EffectiveLogLevel(), gc.Equals, loggo.ERROR)
+	c.Assert(second.LogLevel(), gc.Equals, loggo.UNSPECIFIED)
+	c.Assert(second.EffectiveLogLevel(), gc.Equals, loggo.ERROR)
+
+	first.SetLogLevel(loggo.DEBUG)
+	c.Assert(root.LogLevel(), gc.Equals, loggo.ERROR)
+	c.Assert(root.EffectiveLogLevel(), gc.Equals, loggo.ERROR)
+	c.Assert(first.LogLevel(), gc.Equals, loggo.DEBUG)
+	c.Assert(first.EffectiveLogLevel(), gc.Equals, loggo.DEBUG)
+	c.Assert(second.LogLevel(), gc.Equals, loggo.UNSPECIFIED)
+	c.Assert(second.EffectiveLogLevel(), gc.Equals, loggo.DEBUG)
+
+	second.SetLogLevel(loggo.INFO)
+	c.Assert(root.LogLevel(), gc.Equals, loggo.ERROR)
+	c.Assert(root.EffectiveLogLevel(), gc.Equals, loggo.ERROR)
+	c.Assert(first.LogLevel(), gc.Equals, loggo.DEBUG)
+	c.Assert(first.EffectiveLogLevel(), gc.Equals, loggo.DEBUG)
+	c.Assert(second.LogLevel(), gc.Equals, loggo.INFO)
+	c.Assert(second.EffectiveLogLevel(), gc.Equals, loggo.INFO)
+
+	first.SetLogLevel(loggo.UNSPECIFIED)
+	c.Assert(root.LogLevel(), gc.Equals, loggo.ERROR)
+	c.Assert(root.EffectiveLogLevel(), gc.Equals, loggo.ERROR)
+	c.Assert(first.LogLevel(), gc.Equals, loggo.UNSPECIFIED)
+	c.Assert(first.EffectiveLogLevel(), gc.Equals, loggo.ERROR)
+	c.Assert(second.LogLevel(), gc.Equals, loggo.INFO)
+	c.Assert(second.EffectiveLogLevel(), gc.Equals, loggo.INFO)
+}

--- a/writer.go
+++ b/writer.go
@@ -15,12 +15,12 @@ const defaultWriterName = "default"
 // Writer is implemented by any recipient of log messages.
 type Writer interface {
 	// Write writes a message to the Writer with the given
-	// level and module name. The filename and line hold
+	// level and logger name. The filename and line hold
 	// the file name and line number of the code that is
 	// generating the log message; the time stamp holds
 	// the time the log message was generated, and
 	// message holds the log message itself.
-	Write(level Level, name, filename string, line int, timestamp time.Time, message string)
+	Write(level Level, loggerName, filename string, line int, timestamp time.Time, message string)
 }
 
 // MinLevelWriter is a writer that exposes its minimum log level.
@@ -49,11 +49,11 @@ func (w minLevelWriter) MinLogLevel() Level {
 }
 
 // Write writes the log record.
-func (w minLevelWriter) Write(level Level, module, filename string, line int, timestamp time.Time, message string) {
+func (w minLevelWriter) Write(level Level, loggerName, filename string, line int, timestamp time.Time, message string) {
 	if !IsLevelEnabled(&w, level) {
 		return
 	}
-	w.writer.Write(level, module, filename, line, timestamp, message)
+	w.writer.Write(level, loggerName, filename, line, timestamp, message)
 }
 
 type simpleWriter struct {
@@ -68,7 +68,7 @@ func NewSimpleWriter(writer io.Writer, formatter Formatter) Writer {
 	return &simpleWriter{writer, formatter}
 }
 
-func (simple *simpleWriter) Write(level Level, module, filename string, line int, timestamp time.Time, message string) {
-	logLine := simple.formatter.Format(level, module, filename, line, timestamp, message)
+func (simple *simpleWriter) Write(level Level, loggerName, filename string, line int, timestamp time.Time, message string) {
+	logLine := simple.formatter.Format(level, loggerName, filename, line, timestamp, message)
 	fmt.Fprintln(simple.writer, logLine)
 }


### PR DESCRIPTION
This patch creates a stronger separation between loggers that fit into a hierarchy and those that don't.  loggo.Logger is turned into loggo.SubLogger and a new loggo.Logger interface is added (in part for backward compatibility).

(Review request: http://reviews.vapour.ws/r/4833/)