### PR TITLE
Protect write operations with a muxtex

### DIFF
--- a/context.go
+++ b/context.go
@@ -20,6 +20,9 @@ type Context struct {
 
 	writersMutex sync.Mutex
 	writers      map[string]Writer
+
+	// writeMuxtex is used to serialise write operations.
+	writeMutex sync.Mutex
 }
 
 // NewLoggers returns a new Context with no writers set.
@@ -115,6 +118,8 @@ func (c *Context) ResetLoggerLevels() {
 }
 
 func (c *Context) write(entry Entry) {
+	c.writeMutex.Lock()
+	defer c.writeMutex.Unlock()
 	for _, writer := range c.getWriters() {
 		writer.Write(entry)
 	}


### PR DESCRIPTION
https://bugs.launchpad.net/juju-core/+bug/1609041

Juju CI tests were showing a race. I couldn't reproduce locally, but what appears to be happening is that:

1. getWriters() which is protected by a mutex gives the writers
2. however, there's nothing preventing concurrent writes to each writer

So I added a new mutex to protect the write() api itself.

(Review request: http://reviews.vapour.ws/r/5358/)