### PR TITLE
Add a color writer and make it the new default.

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,0 +1,5 @@
+github.com/juju/ansiterm	git	c368f42cb4b32a70389cded05c7345d9ccdce889	2016-08-17T02:52:20Z
+github.com/lunixbochs/vtclean	git	4fbf7632a2c6d3fbdb9931439bdbbeded02cbe36	2016-01-25T03:51:06Z
+github.com/mattn/go-colorable	git	ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8	2016-07-31T23:54:17Z
+github.com/mattn/go-isatty	git	66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8	2016-08-06T12:27:52Z
+gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z

--- a/example/first.go
+++ b/example/first.go
@@ -22,6 +22,10 @@ func FirstInfo(message string) {
 	first.Infof(message)
 }
 
+func FirstDebug(message string) {
+	first.Debugf(message)
+}
+
 func FirstTrace(message string) {
 	first.Tracef(message)
 }

--- a/example/main.go
+++ b/example/main.go
@@ -28,12 +28,14 @@ func main() {
 	FirstError("first error")
 	FirstWarning("first warning")
 	FirstInfo("first info")
+	FirstDebug("first debug")
 	FirstTrace("first trace")
 
-	SecondCritical("first critical")
-	SecondError("first error")
-	SecondWarning("first warning")
-	SecondInfo("first info")
-	SecondTrace("first trace")
+	SecondCritical("second critical")
+	SecondError("second error")
+	SecondWarning("second warning")
+	SecondInfo("second info")
+	SecondDebug("second debug")
+	SecondTrace("second trace")
 
 }

--- a/example/second.go
+++ b/example/second.go
@@ -22,6 +22,9 @@ func SecondInfo(message string) {
 	second.Infof(message)
 }
 
+func SecondDebug(message string) {
+	second.Debugf(message)
+}
 func SecondTrace(message string) {
 	second.Tracef(message)
 }

--- a/formatter.go
+++ b/formatter.go
@@ -5,6 +5,7 @@ package loggo
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 )
@@ -18,4 +19,20 @@ func DefaultFormatter(entry Entry) string {
 	// Just get the basename from the filename
 	filename := filepath.Base(entry.Filename)
 	return fmt.Sprintf("%s %s %s %s:%d %s", ts, entry.Level, entry.Module, filename, entry.Line, entry.Message)
+}
+
+// TimeFormat is the time format used for the default writer.
+// This can be set with the environment variable LOGGO_TIME_FORMAT.
+var TimeFormat = initTimeFormat()
+
+func initTimeFormat() string {
+	format := os.Getenv("LOGGO_TIME_FORMAT")
+	if format != "" {
+		return format
+	}
+	return "15:04:05"
+}
+
+func formatTime(ts time.Time) string {
+	return ts.Format(TimeFormat)
 }

--- a/level.go
+++ b/level.go
@@ -69,6 +69,27 @@ func (level Level) String() string {
 	}
 }
 
+// Short returns a five character string to use in
+// aligned logging output.
+func (level Level) Short() string {
+	switch level {
+	case TRACE:
+		return "TRACE"
+	case DEBUG:
+		return "DEBUG"
+	case INFO:
+		return "INFO "
+	case WARNING:
+		return "WARN "
+	case ERROR:
+		return "ERROR"
+	case CRITICAL:
+		return "CRITC"
+	default:
+		return "     "
+	}
+}
+
 // get atomically gets the value of the given level.
 func (level *Level) get() Level {
 	return Level(atomic.LoadUint32((*uint32)(level)))

--- a/writer.go
+++ b/writer.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+
+	"github.com/juju/ansiterm"
 )
 
 // DefaultWriterName is the name of the default writer for
@@ -66,5 +69,45 @@ func (simple *simpleWriter) Write(entry Entry) {
 }
 
 func defaultWriter() Writer {
-	return NewSimpleWriter(os.Stderr, DefaultFormatter)
+	return NewColorWriter(os.Stderr)
+}
+
+type colorWriter struct {
+	writer *ansiterm.Writer
+}
+
+var (
+	// SeverityColor defines the colors for the levels output by the ColorWriter.
+	SeverityColor = map[Level]*ansiterm.Context{
+		TRACE:   ansiterm.Foreground(ansiterm.Default),
+		DEBUG:   ansiterm.Foreground(ansiterm.Green),
+		INFO:    ansiterm.Foreground(ansiterm.BrightBlue),
+		WARNING: ansiterm.Foreground(ansiterm.Yellow),
+		ERROR:   ansiterm.Foreground(ansiterm.BrightRed),
+		CRITICAL: &ansiterm.Context{
+			Foreground: ansiterm.White,
+			Background: ansiterm.Red,
+		},
+	}
+	// LocationColor defines the colors for the location output by the ColorWriter.
+	LocationColor = ansiterm.Foreground(ansiterm.BrightBlue)
+)
+
+// NewColorWriter will write out colored severity levels if the writer is
+// outputting to a terminal.
+func NewColorWriter(writer io.Writer) Writer {
+	return &colorWriter{ansiterm.NewWriter(writer)}
+}
+
+// Write implements Writer.
+func (w *colorWriter) Write(entry Entry) {
+	ts := formatTime(entry.Timestamp)
+	// Just get the basename from the filename
+	filename := filepath.Base(entry.Filename)
+
+	fmt.Fprintf(w.writer, "%s ", ts)
+	SeverityColor[entry.Level].Fprintf(w.writer, entry.Level.Short())
+	fmt.Fprintf(w.writer, " %s ", entry.Module)
+	LocationColor.Fprintf(w.writer, "%s:%d ", filename, entry.Line)
+	fmt.Fprintln(w.writer, entry.Message)
 }


### PR DESCRIPTION
The default writer now shows the time in local time, not UTC.
The default writer now shows the severity and location in color if the terminal allows.

(Review request: http://reviews.vapour.ws/r/5466/)