### PR TITLE
Move ANSI terminal color support into loggocolor

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,5 +1,6 @@
-github.com/juju/ansiterm	git	c368f42cb4b32a70389cded05c7345d9ccdce889	2016-08-17T02:52:20Z
+github.com/juju/ansiterm	git	b99631de12cf04a906c1d4e4ec54fb86eae5863d	2016-09-07T23:45:32Z
 github.com/lunixbochs/vtclean	git	4fbf7632a2c6d3fbdb9931439bdbbeded02cbe36	2016-01-25T03:51:06Z
 github.com/mattn/go-colorable	git	ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8	2016-07-31T23:54:17Z
 github.com/mattn/go-isatty	git	66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8	2016-08-06T12:27:52Z
+golang.org/x/sys	git	9bb9f0998d48b31547d975974935ae9b48c7a03c	2016-10-12T00:19:20Z
 gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z

--- a/doc.go
+++ b/doc.go
@@ -36,7 +36,12 @@ logger, but have it emit all logging levels you need to do the following.
 
 	writer, _, err := loggo.RemoveWriter("default")
 	// err is non-nil if and only if the name isn't found.
-	loggo.RegisterWriter("default", writer, loggo.TRACE)
+	loggo.RegisterWriter("default", writer)
 
+To make loggo produce colored output, you can do the following,
+having imported github.com/juju/loggo/loggocolor:
+
+	loggo.RemoveWriter("default")
+	loggo.RegisterWriter("default", loggocolorNewWriter(os.Stderr))
 */
 package loggo

--- a/loggocolor/writer.go
+++ b/loggocolor/writer.go
@@ -1,0 +1,50 @@
+package loggocolor
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/juju/loggo"
+	"github.com/juju/ansiterm"
+)
+
+var (
+	// SeverityColor defines the colors for the levels output by the ColorWriter.
+	SeverityColor = map[loggo.Level]*ansiterm.Context{
+		loggo.TRACE:   ansiterm.Foreground(ansiterm.Default),
+		loggo.DEBUG:   ansiterm.Foreground(ansiterm.Green),
+		loggo.INFO:    ansiterm.Foreground(ansiterm.BrightBlue),
+		loggo.WARNING: ansiterm.Foreground(ansiterm.Yellow),
+		loggo.ERROR:   ansiterm.Foreground(ansiterm.BrightRed),
+		loggo.CRITICAL: &ansiterm.Context{
+			Foreground: ansiterm.White,
+			Background: ansiterm.Red,
+		},
+	}
+	// LocationColor defines the colors for the location output by the ColorWriter.
+	LocationColor = ansiterm.Foreground(ansiterm.BrightBlue)
+)
+
+type colorWriter struct {
+	writer *ansiterm.Writer
+}
+
+// NewColorWriter will write out colored severity levels if the writer is
+// outputting to a terminal.
+func NewWriter(writer io.Writer) loggo.Writer {
+	return &colorWriter{ansiterm.NewWriter(writer)}
+}
+
+// Write implements Writer.
+func (w *colorWriter) Write(entry loggo.Entry) {
+	ts := entry.Timestamp.Format(loggo.TimeFormat)
+	// Just get the basename from the filename
+	filename := filepath.Base(entry.Filename)
+
+	fmt.Fprintf(w.writer, "%s ", ts)
+	SeverityColor[entry.Level].Fprintf(w.writer, entry.Level.Short())
+	fmt.Fprintf(w.writer, " %s ", entry.Module)
+	LocationColor.Fprintf(w.writer, "%s:%d ", filename, entry.Line)
+	fmt.Fprintln(w.writer, entry.Message)
+}

--- a/writer.go
+++ b/writer.go
@@ -7,9 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
-
-	"github.com/juju/ansiterm"
 )
 
 // DefaultWriterName is the name of the default writer for
@@ -69,45 +66,5 @@ func (simple *simpleWriter) Write(entry Entry) {
 }
 
 func defaultWriter() Writer {
-	return NewColorWriter(os.Stderr)
-}
-
-type colorWriter struct {
-	writer *ansiterm.Writer
-}
-
-var (
-	// SeverityColor defines the colors for the levels output by the ColorWriter.
-	SeverityColor = map[Level]*ansiterm.Context{
-		TRACE:   ansiterm.Foreground(ansiterm.Default),
-		DEBUG:   ansiterm.Foreground(ansiterm.Green),
-		INFO:    ansiterm.Foreground(ansiterm.BrightBlue),
-		WARNING: ansiterm.Foreground(ansiterm.Yellow),
-		ERROR:   ansiterm.Foreground(ansiterm.BrightRed),
-		CRITICAL: &ansiterm.Context{
-			Foreground: ansiterm.White,
-			Background: ansiterm.Red,
-		},
-	}
-	// LocationColor defines the colors for the location output by the ColorWriter.
-	LocationColor = ansiterm.Foreground(ansiterm.BrightBlue)
-)
-
-// NewColorWriter will write out colored severity levels if the writer is
-// outputting to a terminal.
-func NewColorWriter(writer io.Writer) Writer {
-	return &colorWriter{ansiterm.NewWriter(writer)}
-}
-
-// Write implements Writer.
-func (w *colorWriter) Write(entry Entry) {
-	ts := formatTime(entry.Timestamp)
-	// Just get the basename from the filename
-	filename := filepath.Base(entry.Filename)
-
-	fmt.Fprintf(w.writer, "%s ", ts)
-	SeverityColor[entry.Level].Fprintf(w.writer, entry.Level.Short())
-	fmt.Fprintf(w.writer, " %s ", entry.Module)
-	LocationColor.Fprintf(w.writer, "%s:%d ", filename, entry.Line)
-	fmt.Fprintln(w.writer, entry.Message)
+	return NewSimpleWriter(os.Stderr, DefaultFormatter)
 }


### PR DESCRIPTION
As discussed on the juju-dev mailing list, it is problematic
that the loggo package emits ANSI escape codes by default.

This PR moves the color support into a sub-package that
can be used optionally when required.
