### PR TITLE
Add Parent and Child methods to the Logger type.

### DIFF
--- a/context.go
+++ b/context.go
@@ -39,6 +39,7 @@ func NewContext(rootLevel Level) *Context {
 		level:   rootLevel,
 		context: context,
 	}
+	context.root.parent = context.root
 	context.modules[""] = context.root
 	return context
 }
@@ -154,6 +155,14 @@ func (c *Context) AddWriter(name string, writer Writer) error {
 	}
 	c.writers[name] = writer
 	return nil
+}
+
+// Writer returns the named writer if one exists.
+// If there is not a writer with the specified name, nil is returned.
+func (c *Context) Writer(name string) Writer {
+	c.writersMutex.Lock()
+	defer c.writersMutex.Unlock()
+	return c.writers[name]
 }
 
 // RemoveWriter remotes the specified writer. If a writer is not found with

--- a/context_test.go
+++ b/context_test.go
@@ -321,6 +321,23 @@ func (*ContextSuite) TestMultipleWriters(c *gc.C) {
 	checkLogEntries(c, third.Log(), expected)
 }
 
+func (*ContextSuite) TestWriter(c *gc.C) {
+	first := &writer{name: "first"}
+	second := &writer{name: "second"}
+	context := loggo.NewContext(loggo.TRACE)
+	err := context.AddWriter("first", first)
+	c.Assert(err, gc.IsNil)
+	err = context.AddWriter("second", second)
+	c.Assert(err, gc.IsNil)
+
+	c.Check(context.Writer("unknown"), gc.IsNil)
+	c.Check(context.Writer("first"), gc.Equals, first)
+	c.Check(context.Writer("second"), gc.Equals, second)
+
+	c.Check(first, gc.Not(gc.Equals), second)
+
+}
+
 type writer struct {
 	loggo.TestWriter
 	// The name exists to discriminate writer equality.

--- a/logger.go
+++ b/logger.go
@@ -27,6 +27,28 @@ func (logger Logger) getModule() *module {
 	return logger.impl
 }
 
+// Parent returns the Logger whose module name is the same
+// as this logger without the last period and suffix.
+// For example the parent of the logger that has the module
+// "a.b.c" is "a.b".
+// The Parent of the root logger is still the root logger.
+func (logger Logger) Parent() Logger {
+	return Logger{logger.getModule().parent}
+}
+
+// Child returns the Logger whose module name is the composed of this
+// Logger's name and the specified name.
+func (logger Logger) Child(name string) Logger {
+	module := logger.getModule()
+	path := module.name
+	if path == "" {
+		path = name
+	} else {
+		path += "." + name
+	}
+	return module.context.GetLogger(path)
+}
+
 // Name returns the logger's module name.
 func (logger Logger) Name() string {
 	return logger.getModule().Name()


### PR DESCRIPTION
Add a way to get related loggers in the same context directly from the Logger type.