### PR TITLE
Added additional severity levels and ability to customize levels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,19 +349,38 @@ Level holds a severity level.
 
 ``` go
 const (
-    UNSPECIFIED Level = iota
-    TRACE
-    DEBUG
-    INFO
-    WARNING
-    ERROR
-    CRITICAL
+	UNSPECIFIED Level = 0000
+	EMERGENCY   Level = 0001
+	ALERT       Level = 1000
+	CRITICAL    Level = 2000
+	ERROR       Level = 3000
+	WARNING     Level = 4000
+	NOTICE      Level = 5000
+	INFO        Level = 6000
+	DEBUG       Level = 7000
+	TRACE       Level = 8000
 )
 ```
-The severity levels. Higher values are more considered more
-important.
+The severity levels. **Lower values** are more considered more
+important, as with syslog. The levels have been synchronized with
+[syslog severity levels](https://en.wikipedia.org/wiki/Syslog#Severity_level) with
+addition of the `TRACE` level.
 
-
+Custom levels may be defined by overriding the `loggo.Levels` map:
+``` go
+var Levels = map[Level]LevelType{
+	UNSPECIFIED: {"", UNSPECIFIED, "UNSPECIFIED"},
+	TRACE:       {"TRACE", TRACE, "TRACE"},
+	DEBUG:       {"DEBUG", DEBUG, "DEBUG"},         
+	INFO:        {"INFO", INFO, "INFO"},            
+	NOTICE:      {"NOTE", NOTICE, "NOTICE"},        
+	WARNING:     {"WARN", WARNING, "WARNING"},      
+	ERROR:       {"ERROR", ERROR, "ERROR"},         
+	CRITICAL:    {"CRIT", CRITICAL, "CRITICAL"},    
+	ALERT:       {"ALERT", ALERT, "ALERT"},         
+	EMERGENCY:   {"EMERG", EMERGENCY, "EMERGENCY"}, 
+}
+```
 
 
 
@@ -567,6 +586,11 @@ the effective log level of the logger.
 Note that the writers may also filter out messages that
 are less than their registered minimum severity level.
 
+**Please note:** As levels *NOTICE*, *ALERT* and *EMERGENCY* are seldom used,
+there are no corresponding `Noticef`, `Alertf` and `Emergencyf` methods. Use
+the method `Logf(level, ...)` instead.
+
+This method is also appropriate if you define your custom log levels.
 
 
 ### func (Logger) Name

--- a/config_test.go
+++ b/config_test.go
@@ -52,7 +52,7 @@ func (*ConfigSuite) TestParseConfigValue(c *gc.C) {
 	}
 }
 
-func (*ConfigSuite) TestPaarseConfigurationString(c *gc.C) {
+func (*ConfigSuite) TestParseConfigurationString(c *gc.C) {
 	for i, test := range []struct {
 		configuration string
 		expected      Config

--- a/context.go
+++ b/context.go
@@ -28,9 +28,12 @@ type Context struct {
 // NewLoggers returns a new Context with no writers set.
 // If the root level is UNSPECIFIED, WARNING is used.
 func NewContext(rootLevel Level) *Context {
-	if rootLevel < TRACE || rootLevel > CRITICAL {
+	if rootLevel == UNSPECIFIED {
+		rootLevel = WARNING
+	} else if _, ok := Levels[rootLevel]; !ok {
 		rootLevel = WARNING
 	}
+
 	context := &Context{
 		modules: make(map[string]*module),
 		writers: make(map[string]Writer),

--- a/context_test.go
+++ b/context_test.go
@@ -38,11 +38,12 @@ func (*ContextSuite) TestNewContextRootLevel(c *gc.C) {
 		level:    loggo.Level(42),
 		expected: loggo.WARNING,
 	}} {
-		c.Log("%d: %s", i, test.level)
+		c.Logf("Iteration %d: level=%v, expected=%v", i, test.level, test.expected)
 		context := loggo.NewContext(test.level)
 		cfg := context.Config()
 		c.Check(cfg, gc.HasLen, 1)
 		value, found := cfg[""]
+		c.Logf("  value=%v found=%v", value, found)
 		c.Check(found, gc.Equals, true)
 		c.Check(value, gc.Equals, test.expected)
 	}

--- a/level.go
+++ b/level.go
@@ -4,6 +4,7 @@
 package loggo
 
 import (
+	"fmt"
 	"strings"
 	"sync/atomic"
 )
@@ -11,83 +12,75 @@ import (
 // The severity levels. Higher values are more considered more
 // important.
 const (
-	UNSPECIFIED Level = iota
-	TRACE
-	DEBUG
-	INFO
-	WARNING
-	ERROR
-	CRITICAL
+	UNSPECIFIED Level = 0000
+	EMERGENCY   Level = 0001 // Syslog level 0
+	ALERT       Level = 1000 // Syslog level 1
+	CRITICAL    Level = 2000 // Syslog level 2
+	ERROR       Level = 3000 // Syslog level 3
+	WARNING     Level = 4000 // Syslog level 4
+	NOTICE      Level = 5000 // Syslog level 5
+	INFO        Level = 6000 // Syslog level 6
+	DEBUG       Level = 7000 // Syslog level 7
+	TRACE       Level = 8000
 )
+
+var Levels = map[Level]LevelType{
+	UNSPECIFIED: {"", UNSPECIFIED, "UNSPECIFIED"},
+	TRACE:       {"TRACE", TRACE, "TRACE"},
+	DEBUG:       {"DEBUG", DEBUG, "DEBUG"},         // Syslog 7
+	INFO:        {"INFO", INFO, "INFO"},            // Syslog 6
+	NOTICE:      {"NOTE", NOTICE, "NOTICE"},        // Syslog 5
+	WARNING:     {"WARN", WARNING, "WARNING"},      // Syslog 4
+	ERROR:       {"ERROR", ERROR, "ERROR"},         // Syslog 3
+	CRITICAL:    {"CRIT", CRITICAL, "CRITICAL"},    // Syslog 2
+	ALERT:       {"ALERT", ALERT, "ALERT"},         // Syslog 1
+	EMERGENCY:   {"EMERG", EMERGENCY, "EMERGENCY"}, // Syslog 0
+}
 
 // Level holds a severity level.
 type Level uint32
 
+type LevelType struct {
+	ShortName string
+	Value     Level
+	LongName  string
+}
+
 // ParseLevel converts a string representation of a logging level to a
 // Level. It returns the level and whether it was valid or not.
 func ParseLevel(level string) (Level, bool) {
-	level = strings.ToUpper(level)
-	switch level {
-	case "UNSPECIFIED":
-		return UNSPECIFIED, true
-	case "TRACE":
-		return TRACE, true
-	case "DEBUG":
-		return DEBUG, true
-	case "INFO":
-		return INFO, true
-	case "WARN", "WARNING":
-		return WARNING, true
-	case "ERROR":
-		return ERROR, true
-	case "CRITICAL":
-		return CRITICAL, true
-	default:
+	if len(level) == 0 {
 		return UNSPECIFIED, false
 	}
+
+	level = strings.ToUpper(level)
+	for _, l := range Levels {
+		if level == l.LongName || level == l.ShortName {
+			return l.Value, true
+		}
+	}
+	return UNSPECIFIED, false
 }
 
 // String implements Stringer.
 func (level Level) String() string {
-	switch level {
-	case UNSPECIFIED:
-		return "UNSPECIFIED"
-	case TRACE:
-		return "TRACE"
-	case DEBUG:
-		return "DEBUG"
-	case INFO:
-		return "INFO"
-	case WARNING:
-		return "WARNING"
-	case ERROR:
-		return "ERROR"
-	case CRITICAL:
-		return "CRITICAL"
-	default:
-		return "<unknown>"
+	if l, ok := Levels[level]; ok {
+		return l.LongName
+	} else {
+		return "UNKNOWN"
 	}
 }
 
 // Short returns a five character string to use in
 // aligned logging output.
 func (level Level) Short() string {
-	switch level {
-	case TRACE:
-		return "TRACE"
-	case DEBUG:
-		return "DEBUG"
-	case INFO:
-		return "INFO "
-	case WARNING:
-		return "WARN "
-	case ERROR:
-		return "ERROR"
-	case CRITICAL:
-		return "CRITC"
-	default:
-		return "     "
+	if l, ok := Levels[level]; ok {
+		return fmt.Sprintf("%5s", l.ShortName)
+	} else {
+		return "UNKNOWN"
 	}
+	return "UNKN "
+
 }
 
 // get atomically gets the value of the given level.

--- a/level_test.go
+++ b/level_test.go
@@ -39,6 +39,12 @@ var parseLevelTests = []struct {
 	str:   "INFO",
 	level: loggo.INFO,
 }, {
+	str:   "notE",
+	level: loggo.NOTICE,
+}, {
+	str:   "NoTICE",
+	level: loggo.NOTICE,
+}, {
 	str:   "warn",
 	level: loggo.WARNING,
 }, {
@@ -60,19 +66,35 @@ var parseLevelTests = []struct {
 	str:   "critical",
 	level: loggo.CRITICAL,
 }, {
-	str:  "not_specified",
-	fail: true,
+	str:   "Alert",
+	level: loggo.ALERT,
 }, {
-	str:  "other",
-	fail: true,
+	str:   "EMERG",
+	level: loggo.EMERGENCY,
 }, {
-	str:  "",
-	fail: true,
+	str:   "EMERGENCY",
+	level: loggo.EMERGENCY,
+}, {
+	str:   "Emerg",
+	level: loggo.EMERGENCY,
+}, {
+	str:   "not_specified",
+	level: loggo.UNSPECIFIED,
+	fail:  true,
+}, {
+	str:   "other",
+	level: loggo.UNSPECIFIED,
+	fail:  true,
+}, {
+	str:   "",
+	level: loggo.UNSPECIFIED,
+	fail:  true,
 }}
 
 func (s *LevelSuite) TestParseLevel(c *gc.C) {
 	for _, test := range parseLevelTests {
 		level, ok := loggo.ParseLevel(test.str)
+		c.Logf("str=%s, level=%v, ok=%v", test.str, level, ok)
 		c.Assert(level, gc.Equals, test.level)
 		c.Assert(ok, gc.Equals, !test.fail)
 	}
@@ -83,10 +105,13 @@ var levelStringValueTests = map[loggo.Level]string{
 	loggo.DEBUG:       "DEBUG",
 	loggo.TRACE:       "TRACE",
 	loggo.INFO:        "INFO",
+	loggo.NOTICE:      "NOTICE",
 	loggo.WARNING:     "WARNING",
 	loggo.ERROR:       "ERROR",
 	loggo.CRITICAL:    "CRITICAL",
-	loggo.Level(42):   "<unknown>", // other values are unknown
+	loggo.ALERT:       "ALERT",
+	loggo.EMERGENCY:   "EMERGENCY",
+	loggo.Level(42):   "UNKNOWN", // other values are unknown
 }
 
 func (s *LevelSuite) TestLevelStringValue(c *gc.C) {

--- a/module.go
+++ b/module.go
@@ -26,10 +26,14 @@ func (module *module) Name() string {
 }
 
 func (m *module) willWrite(level Level) bool {
-	if level < TRACE || level > CRITICAL {
+	if level == UNSPECIFIED {
 		return false
 	}
-	return level >= m.getEffectiveLogLevel()
+	if _, ok := Levels[level]; !ok {
+		return false
+	}
+
+	return level <= m.getEffectiveLogLevel()
 }
 
 func (module *module) getEffectiveLogLevel() Level {


### PR DESCRIPTION
This commit:
- Aligns the severity levels in loggo with syslog severity
  levels. This makes it easier to export logging through loggo
  directly to syslog.
- Enables the user to customize / define custom severity levels.
  Some users like to define levels such as TRACE1, TRACE2 and
  TRACE3 for additional fine logging. This commit makes it possible
  to customize these levels on a per-project basis.

**Backward compatibility notice:** While there should be no issues
with backward compatibility and this should work completely out
of the box, please notice that, to align the code with syslog levels,
the **values for the severity levels have been changed** and now
**lower values** are considered more level.

Signed-off-by: Bojan Čekrlić <verynotbad+github@gmail.com>