### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/context.go
+++ b/context.go
@@ -25,7 +25,7 @@ type Context struct {
 	writeMutex sync.Mutex
 }
 
-// NewLoggers returns a new Context with no writers set.
+// NewContext returns a new Context with no writers set.
 // If the root level is UNSPECIFIED, WARNING is used.
 func NewContext(rootLevel Level) *Context {
 	if rootLevel < TRACE || rootLevel > CRITICAL {

--- a/loggocolor/writer.go
+++ b/loggocolor/writer.go
@@ -30,7 +30,7 @@ type colorWriter struct {
 	writer *ansiterm.Writer
 }
 
-// NewColorWriter will write out colored severity levels if the writer is
+// NewWriter will write out colored severity levels if the writer is
 // outputting to a terminal.
 func NewWriter(writer io.Writer) loggo.Writer {
 	return &colorWriter{ansiterm.NewWriter(writer)}

--- a/writer.go
+++ b/writer.go
@@ -23,7 +23,7 @@ type Writer interface {
 	Write(entry Entry)
 }
 
-// NewMinLevelWriter returns a Writer that will only pass on the Write calls
+// NewMinimumLevelWriter returns a Writer that will only pass on the Write calls
 // to the provided writer if the log level is at or above the specified
 // minimum level.
 func NewMinimumLevelWriter(writer Writer, minLevel Level) Writer {


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?