### PR TITLE
Move ConfigureLoggers to the Context struct.

### DIFF
--- a/context.go
+++ b/context.go
@@ -205,3 +205,21 @@ func (c *Context) ResetWriters() {
 	defer c.writersMutex.Unlock()
 	c.writers = make(map[string]Writer)
 }
+
+// ConfigureLoggers configures loggers according to the given string
+// specification, which specifies a set of modules and their associated
+// logging levels.  Loggers are colon- or semicolon-separated; each
+// module is specified as <modulename>=<level>.  White space outside of
+// module names and levels is ignored.  The root module is specified
+// with the name "<root>".
+//
+// An example specification:
+//	`<root>=ERROR; foo.bar=WARNING`
+func (c *Context) ConfigureLoggers(specification string) error {
+	config, err := ParseConfigString(specification)
+	if err != nil {
+		return err
+	}
+	c.ApplyConfig(config)
+	return nil
+}

--- a/context_test.go
+++ b/context_test.go
@@ -38,7 +38,7 @@ func (*ContextSuite) TestNewContextRootLevel(c *gc.C) {
 		level:    loggo.Level(42),
 		expected: loggo.WARNING,
 	}} {
-		c.Log("%d: %s", i, test.level)
+		c.Logf("%d: %s", i, test.level)
 		context := loggo.NewContext(test.level)
 		cfg := context.Config()
 		c.Check(cfg, gc.HasLen, 1)
@@ -150,6 +150,14 @@ func (*ContextSuite) TestNewLoggerAddsConfig(c *gc.C) {
 		"test":        loggo.UNSPECIFIED,
 		"test.module": loggo.UNSPECIFIED,
 	})
+}
+
+func (*ContextSuite) TestConfigureLoggers(c *gc.C) {
+	context := loggo.NewContext(loggo.INFO)
+	err := context.ConfigureLoggers("testing.module=debug")
+	c.Assert(err, gc.IsNil)
+	expected := "<root>=INFO;testing.module=DEBUG"
+	c.Assert(context.Config().String(), gc.Equals, expected)
 }
 
 func (*ContextSuite) TestApplyNilConfig(c *gc.C) {

--- a/global.go
+++ b/global.go
@@ -66,20 +66,15 @@ func RemoveWriter(name string) (Writer, error) {
 	return defaultContext.RemoveWriter(name)
 }
 
-// ConfigureLoggers configures loggers according to the given string
-// specification, which specifies a set of modules and their associated
-// logging levels.  Loggers are colon- or semicolon-separated; each
-// module is specified as <modulename>=<level>.  White space outside of
-// module names and levels is ignored.  The root module is specified
-// with the name "<root>".
+// ConfigureLoggers configures loggers on the default context according to the
+// given string specification, which specifies a set of modules and their
+// associated logging levels.  Loggers are colon- or semicolon-separated; each
+// module is specified as <modulename>=<level>.  White space outside of module
+// names and levels is ignored.  The root module is specified with the name
+// "<root>".
 //
 // An example specification:
-//	`<root>=ERROR; foo.bar=WARNING`
+//  `<root>=ERROR; foo.bar=WARNING`
 func ConfigureLoggers(specification string) error {
-	config, err := ParseConfigString(specification)
-	if err != nil {
-		return err
-	}
-	defaultContext.ApplyConfig(config)
-	return nil
+	return defaultContext.ConfigureLoggers(specification)
 }


### PR DESCRIPTION
It is good to be able to configure any logging context with a string.