### PR TITLE
Add ability to get Root logger from any Logger.

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -27,6 +27,12 @@ func (logger Logger) getModule() *module {
 	return logger.impl
 }
 
+// Root returns the root logger for the Logger's context.
+func (logger Logger) Root() Logger {
+	module := logger.getModule()
+	return module.context.GetLogger("")
+}
+
 // Parent returns the Logger whose module name is the same
 // as this logger without the last period and suffix.
 // For example the parent of the logger that has the module

--- a/logger_test.go
+++ b/logger_test.go
@@ -180,3 +180,22 @@ func (s *LoggerSuite) TestChildSameContext(c *gc.C) {
 	c.Check(b, gc.Equals, ctx.GetLogger("a.b"))
 	c.Check(b, gc.Not(gc.Equals), loggo.GetLogger("a.b"))
 }
+
+func (s *LoggerSuite) TestRoot(c *gc.C) {
+	logger := loggo.GetLogger("a.b.c")
+	root := logger.Root()
+
+	c.Check(root.Name(), gc.Equals, "<root>")
+	c.Check(root.Child("a.b.c"), gc.Equals, logger)
+}
+
+func (s *LoggerSuite) TestRootSameContext(c *gc.C) {
+	ctx := loggo.NewContext(loggo.DEBUG)
+
+	logger := ctx.GetLogger("a.b.c")
+	root := logger.Root()
+
+	c.Check(root.Name(), gc.Equals, "<root>")
+	c.Check(root.Child("a.b.c"), gc.Equals, logger)
+	c.Check(root.Child("a.b.c"), gc.Not(gc.Equals), loggo.GetLogger("a.b.c"))
+}


### PR DESCRIPTION
This opens up the ability to get a sibling logger easily.
Instead of having to walk up the Parent calls, one could
instead call Root().Child("some.sibling").