### PR TITLE
WIP - logger: Select loggers via wildcards

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -97,6 +97,13 @@ func (*ConfigSuite) TestPaarseConfigurationString(c *gc.C) {
 			"foo.bar": CRITICAL,
 		},
 	}, {
+		configuration: "module=info; a.*.module=debug; b.*.module=warning",
+		expected: Config{
+			"module":     INFO,
+			"a.*.module": DEBUG,
+			"b.*.module": WARNING,
+		},
+	}, {
 		configuration: "foo;bar",
 		err:           `config value expected '=', found "foo"`,
 	}, {

--- a/context_test.go
+++ b/context_test.go
@@ -351,3 +351,26 @@ type writer struct {
 	// The name exists to discriminate writer equality.
 	name string
 }
+
+func (*ContextSuite) TestGetLoggerWildcard(c *gc.C) {
+	writer := &loggo.TestWriter{}
+
+	context := loggo.NewContext(loggo.DEBUG)
+	context.AddWriter("mock", writer)
+
+	fullpath := context.GetLogger("a.name.module")
+	wildcard := context.GetLogger("a.*.module")
+
+	c.Assert(fullpath.Name(), gc.Equals, "a.name.module")
+	c.Assert(wildcard.Name(), gc.Equals, "a.*.module")
+
+	fullpath.Criticalf("hello")
+	wildcard.Criticalf("world")
+
+	logs := writer.Log()
+	c.Assert(logs, gc.HasLen, 2)
+	c.Assert(logs[0].Message, gc.Equals, "hello")
+	c.Assert(logs[0].Module, gc.Equals, "a.name.module")
+	c.Assert(logs[1].Message, gc.Equals, "world")
+	c.Assert(logs[1].Module, gc.Equals, "a.name.module")
+}

--- a/formatter.go
+++ b/formatter.go
@@ -32,7 +32,3 @@ func initTimeFormat() string {
 	}
 	return "15:04:05"
 }
-
-func formatTime(ts time.Time) string {
-	return ts.Format(TimeFormat)
-}

--- a/loggocolor/writer.go
+++ b/loggocolor/writer.go
@@ -17,7 +17,7 @@ var (
 		loggo.INFO:    ansiterm.Foreground(ansiterm.BrightBlue),
 		loggo.WARNING: ansiterm.Foreground(ansiterm.Yellow),
 		loggo.ERROR:   ansiterm.Foreground(ansiterm.BrightRed),
-		loggo.CRITICAL: &ansiterm.Context{
+		loggo.CRITICAL: {
 			Foreground: ansiterm.White,
 			Background: ansiterm.Red,
 		},

--- a/module.go
+++ b/module.go
@@ -10,52 +10,153 @@ const (
 	defaultLevel     = UNSPECIFIED
 )
 
-type module struct {
+type module interface {
+	Name() string
+	FullName() string
+	WillWrite(Level) bool
+	Level() *Level
+	GetEffectiveLogLevel() Level
+	SetLevel(Level)
+	Write(Entry)
+	SetParent(module)
+	Parent() module
+	Context() *Context
+}
+
+type single struct {
 	name    string
-	level   Level
-	parent  *module
+	level   *Level
+	parent  module
 	context *Context
 }
 
 // Name returns the module's name.
-func (module *module) Name() string {
-	if module.name == "" {
-		return rootString
-	}
-	return module.name
+func (m *single) Name() string {
+	return m.name
 }
 
-func (m *module) willWrite(level Level) bool {
+func (m *single) FullName() string {
+	if m.name == "" {
+		return rootString
+	}
+	return m.name
+}
+
+func (m *single) WillWrite(level Level) bool {
 	if level < TRACE || level > CRITICAL {
 		return false
 	}
-	return level >= m.getEffectiveLogLevel()
+	return level >= m.GetEffectiveLogLevel()
 }
 
-func (module *module) getEffectiveLogLevel() Level {
+func (m *single) GetEffectiveLogLevel() Level {
 	// Note: the root module is guaranteed to have a
 	// specified logging level, so acts as a suitable sentinel
 	// for this loop.
+	var p module = m
 	for {
-		if level := module.level.get(); level != UNSPECIFIED {
+		if level := p.Level().get(); level != UNSPECIFIED {
 			return level
 		}
-		module = module.parent
+		p = p.Parent()
 	}
-	panic("unreachable")
 }
 
-// setLevel sets the severity level of the given module.
+func (m *single) Level() *Level {
+	return m.level
+}
+
+// SetLevel sets the severity level of the given module.
 // The root module cannot be set to UNSPECIFIED level.
-func (module *module) setLevel(level Level) {
+func (m *single) SetLevel(level Level) {
 	// The root module can't be unspecified.
-	if module.name == "" && level == UNSPECIFIED {
+	if m.name == "" && level == UNSPECIFIED {
 		level = WARNING
 	}
-	module.level.set(level)
+	m.level.set(level)
 }
 
-func (m *module) write(entry Entry) {
+func (m *single) Write(entry Entry) {
 	entry.Module = m.name
 	m.context.write(entry)
+}
+
+func (m *single) Parent() module {
+	return m.parent
+}
+
+func (m *single) SetParent(p module) {
+	m.parent = p
+}
+
+func (m *single) Context() *Context {
+	return m.context
+}
+
+type multiple struct {
+	name    string
+	modules []module
+}
+
+func (m *multiple) Name() string {
+	return m.name
+}
+
+func (m *multiple) FullName() string {
+	if m.name == "" {
+		return rootString
+	}
+	return m.name
+}
+
+func (m *multiple) WillWrite(level Level) bool {
+	for _, module := range m.modules {
+		if !module.WillWrite(level) {
+			return false
+		}
+	}
+	return true
+}
+
+func (m *multiple) Level() *Level {
+	level := m.GetEffectiveLogLevel()
+	return &level
+}
+
+func (m *multiple) GetEffectiveLogLevel() Level {
+	// Get the highest level...
+	level := UNSPECIFIED
+	for _, module := range m.modules {
+		if m := *module.Level(); m > level {
+			level = m
+		}
+	}
+	if level == UNSPECIFIED {
+		return WARNING
+	}
+	return level
+}
+
+func (m *multiple) SetLevel(level Level) {
+	for _, module := range m.modules {
+		module.SetLevel(level)
+	}
+}
+
+func (m *multiple) Write(entry Entry) {
+	for _, module := range m.modules {
+		module.Write(entry)
+	}
+}
+
+func (m *multiple) Parent() module {
+	return nil
+}
+
+func (m *multiple) SetParent(p module) {
+	// no-op
+}
+
+func (m *multiple) Context() *Context {
+	return nil
 }


### PR DESCRIPTION
The following is a very tentative exploration about if it's possible to
introduce wildcards for selecting loggers.

Normal pattern:

    a.b.x.c; a.b.y.c; a.b.z.c

Wildcard pattern:

    a.b.*.c

The problem with the approach atm is what to do when we don't find any
loggers for that pattern. At the moment it creates them, but we don't
want to create a wildcard logger, so maybe we just try and find the
parent logger to the *:

    `a.b.*.c` would return `a.b`

Additionally, we're using a regexp for access, because it's simple, but
it's not performant. Although the chances of using a wildcard in
production code is low and this should be for gaining access to logs.