### PR TITLE
Logger: Label loggers

### DIFF
--- a/config.go
+++ b/config.go
@@ -47,10 +47,19 @@ func parseConfigValue(value string) (string, Level, error) {
 		return "", UNSPECIFIED, fmt.Errorf("config value %q has missing module name", value)
 	}
 
-	if label := extractConfigLabel(name); label != "" && strings.Contains(label, ".") {
-		// Show the original name and not text potentially extracted config
-		// label.
-		return "", UNSPECIFIED, fmt.Errorf("config label should not contain '.', found %q", name)
+	if label := extractConfigLabel(name); label != "" {
+		if strings.Contains(label, ".") {
+			// Show the original name and not text potentially extracted config
+			// label.
+			return "", UNSPECIFIED, fmt.Errorf("config label should not contain '.', found %q", name)
+		}
+		// Ensure once the normalised extraction has happened, we put the prefix
+		// back on, so that we don't loose the fact that the config is a label.
+		//
+		// Ideally we would change Config from map[string]Level to
+		// map[string]ConfigEntry and then we wouldn't need this step, but that
+		// causes lots of issues in Juju directly.
+		name = fmt.Sprintf("#%s", label)
 	}
 
 	levelStr := strings.TrimSpace(pair[1])
@@ -104,11 +113,11 @@ func ParseConfigString(specification string) (Config, error) {
 
 func extractConfigLabel(s string) string {
 	name := strings.TrimSpace(s)
-	if len(s) < 3 {
+	if len(s) < 2 {
 		return ""
 	}
-	if name[0] == '[' && name[len(name)-1] == ']' {
-		return name[1 : len(name)-1]
+	if name[0] == '#' {
+		return strings.ToLower(name[1:])
 	}
 	return ""
 }

--- a/config.go
+++ b/config.go
@@ -19,7 +19,7 @@ func (c Config) String() string {
 		return ""
 	}
 	// output in alphabetical order.
-	names := []string{}
+	var names []string
 	for name := range c {
 		names = append(names, name)
 	}
@@ -45,6 +45,10 @@ func parseConfigValue(value string) (string, Level, error) {
 	name := strings.TrimSpace(pair[0])
 	if name == "" {
 		return "", UNSPECIFIED, fmt.Errorf("config value %q has missing module name", value)
+	}
+
+	if isConfigLabel(name) && strings.Contains(name, ".") {
+		return "", UNSPECIFIED, fmt.Errorf("config label should not contain '.', found %q", name)
 	}
 
 	levelStr := strings.TrimSpace(pair[1])
@@ -73,6 +77,7 @@ func parseConfigValue(value string) (string, Level, error) {
 //
 // An example specification:
 //	`<root>=ERROR; foo.bar=WARNING`
+//	`[LABEL]=ERROR`
 func ParseConfigString(specification string) (Config, error) {
 	specification = strings.TrimSpace(specification)
 	if specification == "" {
@@ -93,4 +98,12 @@ func ParseConfigString(specification string) (Config, error) {
 		cfg[name] = level
 	}
 	return cfg, nil
+}
+
+func isConfigLabel(s string) bool {
+	name := strings.TrimSpace(s)
+	if len(name) < 3 {
+		return false
+	}
+	return name[0] == '[' && name[len(name)-1] == ']'
 }

--- a/config.go
+++ b/config.go
@@ -47,7 +47,9 @@ func parseConfigValue(value string) (string, Level, error) {
 		return "", UNSPECIFIED, fmt.Errorf("config value %q has missing module name", value)
 	}
 
-	if extractConfigLabel(name) != "" && strings.Contains(name, ".") {
+	if label := extractConfigLabel(name); label != "" && strings.Contains(label, ".") {
+		// Show the original name and not text potentially extracted config
+		// label.
 		return "", UNSPECIFIED, fmt.Errorf("config label should not contain '.', found %q", name)
 	}
 

--- a/config.go
+++ b/config.go
@@ -47,7 +47,7 @@ func parseConfigValue(value string) (string, Level, error) {
 		return "", UNSPECIFIED, fmt.Errorf("config value %q has missing module name", value)
 	}
 
-	if isConfigLabel(name) && strings.Contains(name, ".") {
+	if extractConfigLabel(name) != "" && strings.Contains(name, ".") {
 		return "", UNSPECIFIED, fmt.Errorf("config label should not contain '.', found %q", name)
 	}
 
@@ -100,10 +100,13 @@ func ParseConfigString(specification string) (Config, error) {
 	return cfg, nil
 }
 
-func isConfigLabel(s string) bool {
+func extractConfigLabel(s string) string {
 	name := strings.TrimSpace(s)
-	if len(name) < 3 {
-		return false
+	if len(s) < 3 {
+		return ""
 	}
-	return name[0] == '[' && name[len(name)-1] == ']'
+	if name[0] == '[' && name[len(name)-1] == ']' {
+		return name[1 : len(name)-1]
+	}
+	return ""
 }

--- a/config_test.go
+++ b/config_test.go
@@ -37,6 +37,13 @@ func (*ConfigSuite) TestParseConfigValue(c *gc.C) {
 		value:  "<root> = info",
 		module: "",
 		level:  INFO,
+	}, {
+		value:  "[LABEL] = info",
+		module: "[LABEL]",
+		level:  INFO,
+	}, {
+		value: "[LABEL.1] = info",
+		err:   `config label should not contain '.', found "[LABEL.1]"`,
 	}} {
 		c.Logf("%d: %s", i, test.value)
 		module, level, err := parseConfigValue(test.value)
@@ -72,6 +79,9 @@ func (*ConfigSuite) TestPaarseConfigurationString(c *gc.C) {
 	}, {
 		configuration: "<root>=DEBUG",
 		expected:      Config{"": DEBUG},
+	}, {
+		configuration: "[LABEL]=DEBUG",
+		expected:      Config{"[LABEL]": DEBUG},
 	}, {
 		configuration: "test.module=debug",
 		expected:      Config{"test.module": DEBUG},

--- a/config_test.go
+++ b/config_test.go
@@ -38,12 +38,16 @@ func (*ConfigSuite) TestParseConfigValue(c *gc.C) {
 		module: "",
 		level:  INFO,
 	}, {
-		value:  "[LABEL] = info",
-		module: "[LABEL]",
+		value:  "#label = info",
+		module: "#label",
 		level:  INFO,
 	}, {
-		value: "[LABEL.1] = info",
-		err:   `config label should not contain '.', found "[LABEL.1]"`,
+		value:  "#LABEL = info",
+		module: "#label",
+		level:  INFO,
+	}, {
+		value: "#label.1 = info",
+		err:   `config label should not contain '.', found "#label.1"`,
 	}} {
 		c.Logf("%d: %s", i, test.value)
 		module, level, err := parseConfigValue(test.value)
@@ -80,8 +84,8 @@ func (*ConfigSuite) TestPaarseConfigurationString(c *gc.C) {
 		configuration: "<root>=DEBUG",
 		expected:      Config{"": DEBUG},
 	}, {
-		configuration: "[LABEL]=DEBUG",
-		expected:      Config{"[LABEL]": DEBUG},
+		configuration: "#label=DEBUG",
+		expected:      Config{"#label": DEBUG},
 	}, {
 		configuration: "test.module=debug",
 		expected:      Config{"test.module": DEBUG},

--- a/context.go
+++ b/context.go
@@ -81,11 +81,12 @@ func (c *Context) getLoggerModule(name string, labels []string) *module {
 		labelMap[label] = struct{}{}
 	}
 	impl = &module{
-		name:    name,
-		level:   UNSPECIFIED,
-		parent:  parent,
-		context: c,
-		labels:  labelMap,
+		name:         name,
+		level:        UNSPECIFIED,
+		parent:       parent,
+		context:      c,
+		labels:       labels,
+		labelsLookup: labelMap,
 	}
 	c.modules[name] = impl
 	return impl
@@ -99,7 +100,7 @@ func (c *Context) getLoggerModulesByLabel(label string) []*module {
 			continue
 		}
 
-		if _, ok := mod.labels[label]; ok {
+		if _, ok := mod.labelsLookup[label]; ok {
 			modules = append(modules, mod)
 		}
 	}

--- a/context.go
+++ b/context.go
@@ -140,14 +140,14 @@ func (c *Context) ApplyConfig(config Config) {
 	c.modulesMutex.Lock()
 	defer c.modulesMutex.Unlock()
 	for name, level := range config {
-		if !isConfigLabel(name) {
+		label := extractConfigLabel(name)
+		if label == "" {
 			module := c.getLoggerModule(name, nil)
 			module.setLevel(level)
 			continue
 		}
 
 		// Config contains a named label, use that for selecting the loggers.
-		label := name[1 : len(name)-1]
 		modules := c.getLoggerModulesByLabel(label)
 		for _, module := range modules {
 			module.setLevel(level)

--- a/context.go
+++ b/context.go
@@ -5,6 +5,7 @@ package loggo
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -55,6 +56,26 @@ func (c *Context) GetLogger(name string, labels ...string) Logger {
 	return Logger{
 		impl: c.getLoggerModule(name, labels),
 	}
+}
+
+// GetAllLoggerLabels returns all the logger labels for a given context. The
+// names are unique and sorted before returned, to improve consistency.
+func (c *Context) GetAllLoggerLabels() []string {
+	c.modulesMutex.Lock()
+	defer c.modulesMutex.Unlock()
+
+	names := make(map[string]struct{})
+	for _, module := range c.modules {
+		for k, v := range module.labelsLookup {
+			names[k] = v
+		}
+	}
+	labels := make([]string, 0, len(names))
+	for name := range names {
+		labels = append(labels, name)
+	}
+	sort.Strings(labels)
+	return labels
 }
 
 func (c *Context) getLoggerModule(name string, labels []string) *module {

--- a/context_test.go
+++ b/context_test.go
@@ -216,12 +216,12 @@ func (*ContextSuite) TestApplyConfigAdditive(c *gc.C) {
 
 func (*ContextSuite) TestApplyConfigLabels(c *gc.C) {
 	context := loggo.NewContext(loggo.WARNING)
-	context.GetLogger("a.b", "ONE")
-	context.GetLogger("c.d", "ONE")
-	context.GetLogger("e", "TWO")
+	context.GetLogger("a.b", "one")
+	context.GetLogger("c.d", "one")
+	context.GetLogger("e", "two")
 
-	context.ApplyConfig(loggo.Config{"[ONE]": loggo.TRACE})
-	context.ApplyConfig(loggo.Config{"[TWO]": loggo.DEBUG})
+	context.ApplyConfig(loggo.Config{"#one": loggo.TRACE})
+	context.ApplyConfig(loggo.Config{"#two": loggo.DEBUG})
 
 	c.Assert(context.Config(), gc.DeepEquals,
 		loggo.Config{
@@ -243,8 +243,8 @@ func (*ContextSuite) TestApplyConfigLabels(c *gc.C) {
 
 func (*ContextSuite) TestApplyConfigLabelsAddative(c *gc.C) {
 	context := loggo.NewContext(loggo.WARNING)
-	context.ApplyConfig(loggo.Config{"[ONE]": loggo.TRACE})
-	context.ApplyConfig(loggo.Config{"[TWO]": loggo.DEBUG})
+	context.ApplyConfig(loggo.Config{"#one": loggo.TRACE})
+	context.ApplyConfig(loggo.Config{"#two": loggo.DEBUG})
 	c.Assert(context.Config(), gc.DeepEquals,
 		loggo.Config{
 			"": loggo.WARNING,
@@ -257,21 +257,19 @@ func (*ContextSuite) TestApplyConfigLabelsAddative(c *gc.C) {
 
 func (*ContextSuite) TestApplyConfigWithMalformedLabel(c *gc.C) {
 	context := loggo.NewContext(loggo.WARNING)
-	context.GetLogger("a.b", "ONE")
+	context.GetLogger("a.b", "one")
 
-	context.ApplyConfig(loggo.Config{"[ONE": loggo.TRACE})
+	context.ApplyConfig(loggo.Config{"#ONE.1": loggo.TRACE})
 
 	c.Assert(context.Config(), gc.DeepEquals,
 		loggo.Config{
-			"":     loggo.WARNING,
-			"[ONE": loggo.TRACE,
+			"": loggo.WARNING,
 		})
 	c.Assert(context.CompleteConfig(), gc.DeepEquals,
 		loggo.Config{
-			"":     loggo.WARNING,
-			"a":    loggo.UNSPECIFIED,
-			"a.b":  loggo.UNSPECIFIED,
-			"[ONE": loggo.TRACE,
+			"":    loggo.WARNING,
+			"a":   loggo.UNSPECIFIED,
+			"a.b": loggo.UNSPECIFIED,
 		})
 }
 

--- a/context_test.go
+++ b/context_test.go
@@ -214,6 +214,24 @@ func (*ContextSuite) TestApplyConfigAdditive(c *gc.C) {
 		})
 }
 
+func (*ContextSuite) TestGetAllLoggerLabels(c *gc.C) {
+	context := loggo.NewContext(loggo.WARNING)
+	context.GetLogger("a.b", "one")
+	context.GetLogger("c.d", "one")
+	context.GetLogger("e", "two")
+
+	labels := context.GetAllLoggerLabels()
+	c.Assert(labels, gc.DeepEquals, []string{"one", "two"})
+}
+
+func (*ContextSuite) TestGetAllLoggerLabelsWithApplyConfig(c *gc.C) {
+	context := loggo.NewContext(loggo.WARNING)
+	context.ApplyConfig(loggo.Config{"#one": loggo.TRACE})
+
+	labels := context.GetAllLoggerLabels()
+	c.Assert(labels, gc.DeepEquals, []string{})
+}
+
 func (*ContextSuite) TestApplyConfigLabels(c *gc.C) {
 	context := loggo.NewContext(loggo.WARNING)
 	context.GetLogger("a.b", "one")

--- a/entry.go
+++ b/entry.go
@@ -19,4 +19,6 @@ type Entry struct {
 	Timestamp time.Time
 	// Message is the formatted string from teh log call.
 	Message string
+	// Labels is the label associated with the log message.
+	Labels []string
 }

--- a/formatter.go
+++ b/formatter.go
@@ -32,7 +32,3 @@ func initTimeFormat() string {
 	}
 	return "15:04:05"
 }
-
-func formatTime(ts time.Time) string {
-	return ts.Format(TimeFormat)
-}

--- a/logger.go
+++ b/logger.go
@@ -44,7 +44,20 @@ func (logger Logger) Parent() Logger {
 
 // Child returns the Logger whose module name is the composed of this
 // Logger's name and the specified name.
-func (logger Logger) Child(name string, labels ...string) Logger {
+func (logger Logger) Child(name string) Logger {
+	module := logger.getModule()
+	path := module.name
+	if path == "" {
+		path = name
+	} else {
+		path += "." + name
+	}
+	return module.context.GetLogger(path)
+}
+
+// ChildWithLabels returns the Logger whose module name is the composed of this
+// Logger's name and the specified name with the correct associated labels.
+func (logger Logger) ChildWithLabels(name string, labels ...string) Logger {
 	module := logger.getModule()
 	path := module.name
 	if path == "" {

--- a/logger.go
+++ b/logger.go
@@ -44,7 +44,7 @@ func (logger Logger) Parent() Logger {
 
 // Child returns the Logger whose module name is the composed of this
 // Logger's name and the specified name.
-func (logger Logger) Child(name string) Logger {
+func (logger Logger) Child(name string, labels ...string) Logger {
 	module := logger.getModule()
 	path := module.name
 	if path == "" {
@@ -52,7 +52,7 @@ func (logger Logger) Child(name string) Logger {
 	} else {
 		path += "." + name
 	}
-	return module.context.GetLogger(path)
+	return module.context.GetLogger(path, labels...)
 }
 
 // Name returns the logger's module name.
@@ -63,6 +63,11 @@ func (logger Logger) Name() string {
 // LogLevel returns the configured min log level of the logger.
 func (logger Logger) LogLevel() Level {
 	return logger.getModule().level
+}
+
+// Labels returns the configured labels of the logger.
+func (logger Logger) Labels() []string {
+	return logger.getModule().labels
 }
 
 // EffectiveLogLevel returns the effective min log level of

--- a/logger.go
+++ b/logger.go
@@ -128,12 +128,14 @@ func (logger Logger) LogCallf(calldepth int, level Level, message string, args .
 	if len(args) > 0 {
 		formattedMessage = fmt.Sprintf(message, args...)
 	}
+
 	module.write(Entry{
 		Level:     level,
 		Filename:  file,
 		Line:      line,
 		Timestamp: now,
 		Message:   formattedMessage,
+		Labels:    module.labels,
 	})
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -181,6 +181,17 @@ func (s *LoggerSuite) TestChildSameContext(c *gc.C) {
 	c.Check(b, gc.Not(gc.Equals), loggo.GetLogger("a.b"))
 }
 
+func (s *LoggerSuite) TestChildSameContextWithLabels(c *gc.C) {
+	ctx := loggo.NewContext(loggo.DEBUG)
+
+	logger := ctx.GetLogger("a", "parent")
+	b := logger.Child("b", "child")
+
+	c.Check(ctx.GetAllLoggerLabels(), gc.DeepEquals, []string{"child", "parent"})
+	c.Check(logger.Labels(), gc.DeepEquals, []string{"parent"})
+	c.Check(b.Labels(), gc.DeepEquals, []string{"child"})
+}
+
 func (s *LoggerSuite) TestRoot(c *gc.C) {
 	logger := loggo.GetLogger("a.b.c")
 	root := logger.Root()

--- a/logger_test.go
+++ b/logger_test.go
@@ -185,7 +185,7 @@ func (s *LoggerSuite) TestChildSameContextWithLabels(c *gc.C) {
 	ctx := loggo.NewContext(loggo.DEBUG)
 
 	logger := ctx.GetLogger("a", "parent")
-	b := logger.Child("b", "child")
+	b := logger.ChildWithLabels("b", "child")
 
 	c.Check(ctx.GetAllLoggerLabels(), gc.DeepEquals, []string{"child", "parent"})
 	c.Check(logger.Labels(), gc.DeepEquals, []string{"parent"})

--- a/logging_test.go
+++ b/logging_test.go
@@ -15,15 +15,19 @@ type LoggingSuite struct {
 	context *loggo.Context
 	writer  *writer
 	logger  loggo.Logger
+
+	// Test that labels get outputted to loggo.Entry
+	Labels []string
 }
 
 var _ = gc.Suite(&LoggingSuite{})
+var _ = gc.Suite(&LoggingSuite{Labels: []string{"ONE", "TWO"}})
 
 func (s *LoggingSuite) SetUpTest(c *gc.C) {
 	s.writer = &writer{}
 	s.context = loggo.NewContext(loggo.TRACE)
 	s.context.AddWriter("test", s.writer)
-	s.logger = s.context.GetLogger("test")
+	s.logger = s.context.GetLogger("test", s.Labels...)
 }
 
 func (s *LoggingSuite) TestLoggingStrings(c *gc.C) {
@@ -33,10 +37,10 @@ func (s *LoggingSuite) TestLoggingStrings(c *gc.C) {
 	s.logger.Infof("missing %s")
 
 	checkLogEntries(c, s.writer.Log(), []loggo.Entry{
-		{Level: loggo.INFO, Module: "test", Message: "simple"},
-		{Level: loggo.INFO, Module: "test", Message: "with args 42"},
-		{Level: loggo.INFO, Module: "test", Message: "working 100%"},
-		{Level: loggo.INFO, Module: "test", Message: "missing %s"},
+		{Level: loggo.INFO, Module: "test", Message: "simple", Labels: s.Labels},
+		{Level: loggo.INFO, Module: "test", Message: "with args 42", Labels: s.Labels},
+		{Level: loggo.INFO, Module: "test", Message: "working 100%", Labels: s.Labels},
+		{Level: loggo.INFO, Module: "test", Message: "missing %s", Labels: s.Labels},
 	})
 }
 
@@ -47,9 +51,9 @@ func (s *LoggingSuite) TestLoggingLimitWarning(c *gc.C) {
 	end := time.Now()
 	entries := s.writer.Log()
 	checkLogEntries(c, entries, []loggo.Entry{
-		{Level: loggo.CRITICAL, Module: "test", Message: "something critical"},
-		{Level: loggo.ERROR, Module: "test", Message: "an error"},
-		{Level: loggo.WARNING, Module: "test", Message: "a warning message"},
+		{Level: loggo.CRITICAL, Module: "test", Message: "something critical", Labels: s.Labels},
+		{Level: loggo.ERROR, Module: "test", Message: "an error", Labels: s.Labels},
+		{Level: loggo.WARNING, Module: "test", Message: "a warning message", Labels: s.Labels},
 	})
 
 	for _, entry := range entries {

--- a/loggocolor/writer.go
+++ b/loggocolor/writer.go
@@ -17,7 +17,7 @@ var (
 		loggo.INFO:    ansiterm.Foreground(ansiterm.BrightBlue),
 		loggo.WARNING: ansiterm.Foreground(ansiterm.Yellow),
 		loggo.ERROR:   ansiterm.Foreground(ansiterm.BrightRed),
-		loggo.CRITICAL: &ansiterm.Context{
+		loggo.CRITICAL: {
 			Foreground: ansiterm.White,
 			Background: ansiterm.Red,
 		},

--- a/module.go
+++ b/module.go
@@ -15,6 +15,7 @@ type module struct {
 	level   Level
 	parent  *module
 	context *Context
+	labels  map[string]struct{}
 }
 
 // Name returns the module's name.
@@ -42,7 +43,6 @@ func (module *module) getEffectiveLogLevel() Level {
 		}
 		module = module.parent
 	}
-	panic("unreachable")
 }
 
 // setLevel sets the severity level of the given module.

--- a/module.go
+++ b/module.go
@@ -15,15 +15,17 @@ type module struct {
 	level   Level
 	parent  *module
 	context *Context
-	labels  map[string]struct{}
+
+	labels       []string
+	labelsLookup map[string]struct{}
 }
 
 // Name returns the module's name.
-func (module *module) Name() string {
-	if module.name == "" {
+func (m *module) Name() string {
+	if m.name == "" {
 		return rootString
 	}
-	return module.name
+	return m.name
 }
 
 func (m *module) willWrite(level Level) bool {
@@ -33,26 +35,26 @@ func (m *module) willWrite(level Level) bool {
 	return level >= m.getEffectiveLogLevel()
 }
 
-func (module *module) getEffectiveLogLevel() Level {
+func (m *module) getEffectiveLogLevel() Level {
 	// Note: the root module is guaranteed to have a
 	// specified logging level, so acts as a suitable sentinel
 	// for this loop.
 	for {
-		if level := module.level.get(); level != UNSPECIFIED {
+		if level := m.level.get(); level != UNSPECIFIED {
 			return level
 		}
-		module = module.parent
+		m = m.parent
 	}
 }
 
 // setLevel sets the severity level of the given module.
 // The root module cannot be set to UNSPECIFIED level.
-func (module *module) setLevel(level Level) {
+func (m *module) setLevel(level Level) {
 	// The root module can't be unspecified.
-	if module.name == "" && level == UNSPECIFIED {
+	if m.name == "" && level == UNSPECIFIED {
 		level = WARNING
 	}
-	module.level.set(level)
+	m.level.set(level)
 }
 
 func (m *module) write(entry Entry) {

--- a/writer_test.go
+++ b/writer_test.go
@@ -31,6 +31,28 @@ func (s *SimpleWriterSuite) TestNewSimpleWriter(c *gc.C) {
 		Line:      12,
 		Timestamp: now,
 		Message:   "a message",
+		Labels:    nil,
+	})
+
+	c.Check(buf.String(), gc.Equals, "<< a message >>\n")
+}
+
+func (s *SimpleWriterSuite) TestNewSimpleWriterWithLabels(c *gc.C) {
+	now := time.Now()
+	formatter := func(entry loggo.Entry) string {
+		return "<< " + entry.Message + " >>"
+	}
+	buf := &bytes.Buffer{}
+
+	writer := loggo.NewSimpleWriter(buf, formatter)
+	writer.Write(loggo.Entry{
+		Level:     loggo.INFO,
+		Module:    "test",
+		Filename:  "somefile.go",
+		Line:      12,
+		Timestamp: now,
+		Message:   "a message",
+		Labels:    []string{"ONE", "TWO"},
 	})
 
 	c.Check(buf.String(), gc.Equals, "<< a message >>\n")


### PR DESCRIPTION
The following allows loggers to be tagged with labels, these labels can
be used when applying the configuration. With this change users of the
logging library can change the level of a series of loggers using the
tagged label.

The driver behind this is to better expose loggers within Juju. If a
user wanted to see all HTTP client connections, then a logger will
be tagged with `GetLogger('a.b.c', HTTP)`. Using the model-config
within Juju, it will be possible to set `[HTTP]=TRACE` and all HTTP
loggers will be set to the appropriate level.

---

Concerns:

 1. No validation on namespaces for loggers is performed, other than
 ensuring that ";" and "." are split. Meaning that "[]" for label syntax
 might already exist in the wild?
 2. What do we do about malformed "[", or "]" labels?

---

Alternative syntax for labels:

 1. "<>"
 2. "{}"

---

See: #39 