### PR TITLE
Logging: Structured logging

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -3,14 +3,18 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/juju/loggo"
+	"github.com/juju/loggo/loggostructured"
 )
 
-var logger = loggo.GetLogger("main")
 var rootLogger = loggo.GetLogger("")
 
 func main() {
+	loggo.ResetWriters()
+	loggo.DefaultContext().AddWriter("structured", loggostructured.NewWriter(os.Stdout, time.RFC3339))
+
 	args := os.Args
 	if len(args) > 1 {
 		loggo.ConfigureLoggers(args[1])

--- a/loggostructured/writer.go
+++ b/loggostructured/writer.go
@@ -1,0 +1,50 @@
+package loggostructured
+
+import (
+	"encoding/json"
+	"io"
+	"path/filepath"
+
+	"github.com/juju/loggo"
+)
+
+type structuredWriter struct {
+	encoder    *json.Encoder
+	timeFormat string
+}
+
+// NewWriter will write out structured logs to the writer.
+// We fallback to JSON Codec for encoding all loggo.Entries.
+func NewWriter(writer io.Writer, timeFormat string) loggo.Writer {
+	return &structuredWriter{
+		encoder:    json.NewEncoder(writer),
+		timeFormat: timeFormat,
+	}
+}
+
+// Write implements Writer.
+func (w *structuredWriter) Write(entry loggo.Entry) {
+	ts := entry.Timestamp.Format(w.timeFormat)
+	// Just get the basename from the filename
+	filename := filepath.Base(entry.Filename)
+
+	_ = w.encoder.Encode(line{
+		Timestamp: ts,
+		Filename:  filename,
+		Line:      entry.Line,
+		Level:     entry.Level.Short(),
+		Module:    entry.Module,
+		Message:   entry.Message,
+		Labels:    entry.Labels,
+	})
+}
+
+type line struct {
+	Timestamp string   `json:"ts"`
+	Filename  string   `json:"path"`
+	Line      int      `json:"line"`
+	Level     string   `json:"level"`
+	Module    string   `json:"module"`
+	Message   string   `json:"message"`
+	Labels    []string `json:"labels,omitempty"`
+}


### PR DESCRIPTION
This basically adds structured logging to loggo. This is very tentative
exploration into better logging output for juju. Structured logging
offers better introspection and have better tooling than just using
grep/less/cat et al.

The problem we have here, is that Message in loggo.Entry is just a fat
dump of rubbish. I think the way forward here is to open up a new
function to pass anything to logging and so it can be encoded via the
writer.

Something similar to:

    logger.With("component", "client").Infof("message")

Then it can be passed internally when Infof is actually called.