### PR TITLE
Add a labels string map to the logger to pass to each log entry from that logger.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 # loggo
-    import "github.com/juju/loggo"
+    import "github.com/juju/loggo/v2"
 
 [![GoDoc](https://godoc.org/github.com/juju/loggo?status.svg)](https://godoc.org/github.com/juju/loggo)
 

--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -7,8 +7,9 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/juju/loggo"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/loggo/v2"
 )
 
 type BenchmarksSuite struct {

--- a/context_test.go
+++ b/context_test.go
@@ -4,7 +4,7 @@
 package loggo_test
 
 import (
-	"github.com/juju/loggo"
+	"github.com/juju/loggo/v2"
 
 	gc "gopkg.in/check.v1"
 )

--- a/context_test.go
+++ b/context_test.go
@@ -5,6 +5,7 @@ package loggo_test
 
 import (
 	"github.com/juju/loggo"
+
 	gc "gopkg.in/check.v1"
 )
 
@@ -75,14 +76,14 @@ func (*ContextSuite) TestGetLoggerRoot(c *gc.C) {
 	context := loggo.NewContext(loggo.DEBUG)
 	blank := context.GetLogger("")
 	root := context.GetLogger("<root>")
-	c.Assert(blank, gc.Equals, root)
+	c.Assert(blank, gc.DeepEquals, root)
 }
 
 func (*ContextSuite) TestGetLoggerCase(c *gc.C) {
 	context := loggo.NewContext(loggo.DEBUG)
 	upper := context.GetLogger("TEST")
 	lower := context.GetLogger("test")
-	c.Assert(upper, gc.Equals, lower)
+	c.Assert(upper, gc.DeepEquals, lower)
 	c.Assert(upper.Name(), gc.Equals, "test")
 }
 
@@ -90,7 +91,7 @@ func (*ContextSuite) TestGetLoggerSpace(c *gc.C) {
 	context := loggo.NewContext(loggo.DEBUG)
 	space := context.GetLogger(" test ")
 	lower := context.GetLogger("test")
-	c.Assert(space, gc.Equals, lower)
+	c.Assert(space, gc.DeepEquals, lower)
 	c.Assert(space.Name(), gc.Equals, "test")
 }
 

--- a/entry.go
+++ b/entry.go
@@ -19,6 +19,6 @@ type Entry struct {
 	Timestamp time.Time
 	// Message is the formatted string from teh log call.
 	Message string
-	// Labels is the label associated with the log message.
-	Labels []string
+	// Labels are the labels associated with the log message.
+	Labels Labels
 }

--- a/example/first.go
+++ b/example/first.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/juju/loggo"
+	"github.com/juju/loggo/v2"
 )
 
 var first = loggo.GetLogger("first")

--- a/example/main.go
+++ b/example/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/juju/loggo"
+	"github.com/juju/loggo/v2"
 )
 
 var rootLogger = loggo.GetLogger("")

--- a/example/second.go
+++ b/example/second.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/juju/loggo"
+	"github.com/juju/loggo/v2"
 )
 
 var second = loggo.GetLogger("second")

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -8,7 +8,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/loggo"
+	"github.com/juju/loggo/v2"
 )
 
 type formatterSuite struct{}

--- a/global.go
+++ b/global.go
@@ -34,10 +34,10 @@ func GetLogger(name string) Logger {
 	return defaultContext.GetLogger(name)
 }
 
-// GetLogger returns a Logger for the given module name with the correct
-// assiciated labels, creating it and its parents if necessary.
-func GetLoggerWithLabels(name string, labels ...string) Logger {
-	return defaultContext.GetLogger(name, labels...)
+// GetLoggerWithTags returns a Logger for the given module name with the correct
+// associated tags, creating it and its parents if necessary.
+func GetLoggerWithTags(name string, tags ...string) Logger {
+	return defaultContext.GetLogger(name, tags...)
 }
 
 // ResetLogging iterates through the known modules and sets the levels of all
@@ -82,7 +82,8 @@ func RemoveWriter(name string) (Writer, error) {
 // "<root>".
 //
 // An example specification:
-//  `<root>=ERROR; foo.bar=WARNING`
+//
+//	`<root>=ERROR; foo.bar=WARNING`
 func ConfigureLoggers(specification string) error {
 	return defaultContext.ConfigureLoggers(specification)
 }

--- a/global_test.go
+++ b/global_test.go
@@ -4,8 +4,9 @@
 package loggo_test
 
 import (
-	"github.com/juju/loggo"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/loggo"
 )
 
 type GlobalSuite struct{}
@@ -86,7 +87,7 @@ func (*GlobalSuite) TestRemoveWriter(c *gc.C) {
 	c.Assert(loggo.DefaultContext().WriterNames(), gc.HasLen, 0)
 }
 
-func (s *GlobalSuite) TestGetLoggerWithLabels(c *gc.C) {
-	logger := loggo.GetLoggerWithLabels("parent", "labela", "labelb")
-	c.Check(logger.Labels(), gc.DeepEquals, []string{"labela", "labelb"})
+func (s *GlobalSuite) TestGetLoggerWithTags(c *gc.C) {
+	logger := loggo.GetLoggerWithTags("parent", "labela", "labelb")
+	c.Check(logger.Tags(), gc.DeepEquals, []string{"labela", "labelb"})
 }

--- a/global_test.go
+++ b/global_test.go
@@ -6,7 +6,7 @@ package loggo_test
 import (
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/loggo"
+	"github.com/juju/loggo/v2"
 )
 
 type GlobalSuite struct{}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juju/loggo
+module github.com/juju/loggo/v2
 
 go 1.21
 

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,15 @@
 module github.com/juju/loggo
 
-go 1.14
+go 1.21
 
 require (
 	github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a
-	github.com/lunixbochs/vtclean v0.0.0-20160125035106-4fbf7632a2c6
-	github.com/mattn/go-colorable v0.0.6
-	github.com/mattn/go-isatty v0.0.0-20160806122752-66b8e73f3f5c
 	gopkg.in/check.v1 v1.0.0-20160105164936-4f90aeace3a2
+)
+
+require (
+	github.com/lunixbochs/vtclean v0.0.0-20160125035106-4fbf7632a2c6 // indirect
+	github.com/mattn/go-colorable v0.0.6 // indirect
+	github.com/mattn/go-isatty v0.0.0-20160806122752-66b8e73f3f5c // indirect
+	golang.org/x/sys v0.16.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,12 @@
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a h1:FaWFmfWdAUKbSCtOU2QjDaorUexogfaMgbipgYATUMU=
 github.com/juju/ansiterm v0.0.0-20180109212912-720a0952cc2a/go.mod h1:UJSiEoRfvx3hP73CvoARgeLjaIOjybY9vj8PUPPFGeU=
+github.com/lunixbochs/vtclean v0.0.0-20160125035106-4fbf7632a2c6 h1:yjdywwaxd8vTEXuA4EdgUBkiCQEQG7YAY3k9S1PaZKg=
 github.com/lunixbochs/vtclean v0.0.0-20160125035106-4fbf7632a2c6/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/mattn/go-colorable v0.0.6 h1:jGqlOoCjqVR4hfTO9H1qrR2xi0xZNYmX2T1xlw7P79c=
 github.com/mattn/go-colorable v0.0.6/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.0-20160806122752-66b8e73f3f5c h1:3nKFouDdpgGUV/uerJcYWH45ZbJzX0SiVWfTgmUeTzc=
 github.com/mattn/go-isatty v0.0.0-20160806122752-66b8e73f3f5c/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+golang.org/x/sys v0.16.0 h1:xWw16ngr6ZMtmxDyKyIgsE93KNKz5HKmMa3b8ALHidU=
+golang.org/x/sys v0.16.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v1.0.0-20160105164936-4f90aeace3a2 h1:+j1SppRob9bAgoYmsdW9NNBdKZfgYuWpqnYHv78Qt8w=
 gopkg.in/check.v1 v1.0.0-20160105164936-4f90aeace3a2/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/labels.go
+++ b/labels.go
@@ -1,0 +1,13 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package loggo
+
+const (
+	// LoggerTags is the name of the label used to record the
+	// logger tags for a log entry.
+	LoggerTags = "logger-tags"
+)
+
+// Labels represents key values which are assigned to a log entry.
+type Labels map[string]string

--- a/level_test.go
+++ b/level_test.go
@@ -6,7 +6,7 @@ package loggo_test
 import (
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/loggo"
+	"github.com/juju/loggo/v2"
 )
 
 type LevelSuite struct{}

--- a/logger_test.go
+++ b/logger_test.go
@@ -6,7 +6,7 @@ package loggo_test
 import (
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/loggo"
+	"github.com/juju/loggo/v2"
 )
 
 type LoggerSuite struct{}

--- a/logger_test.go
+++ b/logger_test.go
@@ -28,6 +28,35 @@ func (s *LoggerSuite) TestRootLogger(c *gc.C) {
 	c.Check(root.IsTraceEnabled(), gc.Equals, false)
 }
 
+func (s *LoggerSuite) TestWithLabels(c *gc.C) {
+	writer := &loggo.TestWriter{}
+	context := loggo.NewContext(loggo.INFO)
+	err := context.AddWriter("test", writer)
+	c.Assert(err, gc.IsNil)
+
+	logger := context.GetLogger("testing")
+	loggerWithLabels := logger.WithLabels(loggo.Labels{"foo": "bar"})
+	loggerWithTagsAndLabels := logger.
+		ChildWithTags("withTags", "tag1", "tag2").
+		WithLabels(loggo.Labels{"hello": "world"})
+
+	logger.Logf(loggo.INFO, "without labels")
+	loggerWithLabels.Logf(loggo.INFO, "with labels")
+	loggerWithTagsAndLabels.Logf(loggo.INFO, "with tags and labels")
+
+	logs := writer.Log()
+	c.Assert(logs, gc.HasLen, 3)
+	c.Check(logs[0].Message, gc.Equals, "without labels")
+	c.Check(logs[0].Labels, gc.HasLen, 0)
+	c.Check(logs[1].Message, gc.Equals, "with labels")
+	c.Check(logs[1].Labels, gc.DeepEquals, loggo.Labels{"foo": "bar"})
+	c.Check(logs[2].Message, gc.Equals, "with tags and labels")
+	c.Check(logs[2].Labels, gc.DeepEquals, loggo.Labels{
+		"logger-tags": "tag1,tag2",
+		"hello":       "world",
+	})
+}
+
 func (s *LoggerSuite) TestSetLevel(c *gc.C) {
 	logger := loggo.GetLogger("testing")
 
@@ -147,7 +176,7 @@ func (s *LoggerSuite) TestParent(c *gc.C) {
 	c.Check(b.Name(), gc.Equals, "a.b")
 	c.Check(a.Name(), gc.Equals, "a")
 	c.Check(root.Name(), gc.Equals, "<root>")
-	c.Check(root.Parent(), gc.Equals, root)
+	c.Check(root.Parent(), gc.DeepEquals, root)
 }
 
 func (s *LoggerSuite) TestParentSameContext(c *gc.C) {
@@ -156,8 +185,8 @@ func (s *LoggerSuite) TestParentSameContext(c *gc.C) {
 	logger := ctx.GetLogger("a.b.c")
 	b := logger.Parent()
 
-	c.Check(b, gc.Equals, ctx.GetLogger("a.b"))
-	c.Check(b, gc.Not(gc.Equals), loggo.GetLogger("a.b"))
+	c.Check(b, gc.DeepEquals, ctx.GetLogger("a.b"))
+	c.Check(b, gc.Not(gc.DeepEquals), loggo.GetLogger("a.b"))
 }
 
 func (s *LoggerSuite) TestChild(c *gc.C) {
@@ -168,7 +197,7 @@ func (s *LoggerSuite) TestChild(c *gc.C) {
 
 	c.Check(a.Name(), gc.Equals, "a")
 	c.Check(logger.Name(), gc.Equals, "a.b.c")
-	c.Check(logger.Parent(), gc.Equals, a.Child("b"))
+	c.Check(logger.Parent(), gc.DeepEquals, a.Child("b"))
 }
 
 func (s *LoggerSuite) TestChildSameContext(c *gc.C) {
@@ -177,19 +206,19 @@ func (s *LoggerSuite) TestChildSameContext(c *gc.C) {
 	logger := ctx.GetLogger("a")
 	b := logger.Child("b")
 
-	c.Check(b, gc.Equals, ctx.GetLogger("a.b"))
-	c.Check(b, gc.Not(gc.Equals), loggo.GetLogger("a.b"))
+	c.Check(b, gc.DeepEquals, ctx.GetLogger("a.b"))
+	c.Check(b, gc.Not(gc.DeepEquals), loggo.GetLogger("a.b"))
 }
 
 func (s *LoggerSuite) TestChildSameContextWithLabels(c *gc.C) {
 	ctx := loggo.NewContext(loggo.DEBUG)
 
 	logger := ctx.GetLogger("a", "parent")
-	b := logger.ChildWithLabels("b", "child")
+	b := logger.ChildWithTags("b", "child")
 
 	c.Check(ctx.GetAllLoggerLabels(), gc.DeepEquals, []string{"child", "parent"})
-	c.Check(logger.Labels(), gc.DeepEquals, []string{"parent"})
-	c.Check(b.Labels(), gc.DeepEquals, []string{"child"})
+	c.Check(logger.Tags(), gc.DeepEquals, []string{"parent"})
+	c.Check(b.Tags(), gc.DeepEquals, []string{"child"})
 }
 
 func (s *LoggerSuite) TestRoot(c *gc.C) {
@@ -197,7 +226,7 @@ func (s *LoggerSuite) TestRoot(c *gc.C) {
 	root := logger.Root()
 
 	c.Check(root.Name(), gc.Equals, "<root>")
-	c.Check(root.Child("a.b.c"), gc.Equals, logger)
+	c.Check(root.Child("a.b.c"), gc.DeepEquals, logger)
 }
 
 func (s *LoggerSuite) TestRootSameContext(c *gc.C) {
@@ -207,6 +236,6 @@ func (s *LoggerSuite) TestRootSameContext(c *gc.C) {
 	root := logger.Root()
 
 	c.Check(root.Name(), gc.Equals, "<root>")
-	c.Check(root.Child("a.b.c"), gc.Equals, logger)
-	c.Check(root.Child("a.b.c"), gc.Not(gc.Equals), loggo.GetLogger("a.b.c"))
+	c.Check(root.Child("a.b.c"), gc.DeepEquals, logger)
+	c.Check(root.Child("a.b.c"), gc.Not(gc.DeepEquals), loggo.GetLogger("a.b.c"))
 }

--- a/logging_test.go
+++ b/logging_test.go
@@ -17,18 +17,18 @@ type LoggingSuite struct {
 	logger  loggo.Logger
 
 	// Test that labels get outputted to loggo.Entry
-	Labels []string
+	Labels map[string]string
 }
 
 var _ = gc.Suite(&LoggingSuite{})
-var _ = gc.Suite(&LoggingSuite{Labels: []string{"ONE", "TWO"}})
+var _ = gc.Suite(&LoggingSuite{Labels: loggo.Labels{"logger-tags": "ONE,TWO"}})
 
 func (s *LoggingSuite) SetUpTest(c *gc.C) {
 	s.writer = &writer{}
 	s.context = loggo.NewContext(loggo.TRACE)
 	err := s.context.AddWriter("test", s.writer)
 	c.Assert(err, gc.IsNil)
-	s.logger = s.context.GetLogger("test", s.Labels...)
+	s.logger = s.context.GetLogger("test", "ONE,TWO")
 }
 
 func (s *LoggingSuite) TestLoggingStrings(c *gc.C) {

--- a/logging_test.go
+++ b/logging_test.go
@@ -8,7 +8,7 @@ import (
 
 	gc "gopkg.in/check.v1"
 
-	"github.com/juju/loggo"
+	"github.com/juju/loggo/v2"
 )
 
 type LoggingSuite struct {

--- a/loggocolor/writer.go
+++ b/loggocolor/writer.go
@@ -6,7 +6,8 @@ import (
 	"path/filepath"
 
 	"github.com/juju/ansiterm"
-	"github.com/juju/loggo"
+
+	"github.com/juju/loggo/v2"
 )
 
 var (

--- a/module.go
+++ b/module.go
@@ -14,7 +14,7 @@ type module struct {
 	parent  *module
 	context *Context
 
-	labels       []string
+	tags         []string
 	labelsLookup map[string]struct{}
 }
 

--- a/util_test.go
+++ b/util_test.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 	"strings"
 
-	"github.com/juju/loggo"
+	"github.com/juju/loggo/v2"
 
 	gc "gopkg.in/check.v1"
 )

--- a/writer_test.go
+++ b/writer_test.go
@@ -1,15 +1,13 @@
 // Copyright 2014 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENCE file for details.
 
-package loggo_test
+package loggo
 
 import (
 	"bytes"
 	"time"
 
 	gc "gopkg.in/check.v1"
-
-	"github.com/juju/loggo"
 )
 
 type SimpleWriterSuite struct{}
@@ -18,14 +16,14 @@ var _ = gc.Suite(&SimpleWriterSuite{})
 
 func (s *SimpleWriterSuite) TestNewSimpleWriter(c *gc.C) {
 	now := time.Now()
-	formatter := func(entry loggo.Entry) string {
+	formatter := func(entry Entry) string {
 		return "<< " + entry.Message + " >>"
 	}
 	buf := &bytes.Buffer{}
 
-	writer := loggo.NewSimpleWriter(buf, formatter)
-	writer.Write(loggo.Entry{
-		Level:     loggo.INFO,
+	writer := NewSimpleWriter(buf, formatter)
+	writer.Write(Entry{
+		Level:     INFO,
 		Module:    "test",
 		Filename:  "somefile.go",
 		Line:      12,
@@ -39,20 +37,20 @@ func (s *SimpleWriterSuite) TestNewSimpleWriter(c *gc.C) {
 
 func (s *SimpleWriterSuite) TestNewSimpleWriterWithLabels(c *gc.C) {
 	now := time.Now()
-	formatter := func(entry loggo.Entry) string {
+	formatter := func(entry Entry) string {
 		return "<< " + entry.Message + " >>"
 	}
 	buf := &bytes.Buffer{}
 
-	writer := loggo.NewSimpleWriter(buf, formatter)
-	writer.Write(loggo.Entry{
-		Level:     loggo.INFO,
+	writer := NewSimpleWriter(buf, formatter)
+	writer.Write(Entry{
+		Level:     INFO,
 		Module:    "test",
 		Filename:  "somefile.go",
 		Line:      12,
 		Timestamp: now,
 		Message:   "a message",
-		Labels:    []string{"ONE", "TWO"},
+		Labels:    Labels{LoggerTags: "ONE,TWO"},
 	})
 
 	c.Check(buf.String(), gc.Equals, "<< a message >>\n")


### PR DESCRIPTION
We want to be able to generate log entries with key value labels. We already in loggo have the concept of labels to group logger modules together with a common name. This PR changes that terminology to "tags" and introduces labels as a map of strings which can be attached to logger instances. Each time a logger instance creates a log entry to hand off to the writer, it adds the labels is has to the log entry. 

To add labels to a logger, use the WithLabels() method.

The (now called) tags are included in the labels map with the special key name "logger-tags". This still allows filtering of log entries by tag name like we rely on in places like juju debug-log etc.