### PR TITLE
Add LogWithLabelsf to dynamically add extra labels to a log entry

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -186,19 +186,17 @@ func (logger Logger) logCallf(calldepth int, level Level, message string, extraL
 		Timestamp: now,
 		Message:   formattedMessage,
 	}
-	if len(module.tags) > 0 || len(logger.labels) > 0 || len(extraLabels) > 0 {
+	entry.Labels = make(Labels)
+	if len(module.tags) > 0 {
 		entry.Labels = make(Labels)
-		if len(module.tags) > 0 {
-			entry.Labels = make(Labels)
-			entry.Labels[LoggerTags] = strings.Join(module.tags, ",")
-		}
-		for k, v := range logger.labels {
-			entry.Labels[k] = v
-		}
-		// Add extra labels if there's any given.
-		for k, v := range extraLabels {
-			entry.Labels[k] = v
-		}
+		entry.Labels[LoggerTags] = strings.Join(module.tags, ",")
+	}
+	for k, v := range logger.labels {
+		entry.Labels[k] = v
+	}
+	// Add extra labels if there's any given.
+	for k, v := range extraLabels {
+		entry.Labels[k] = v
 	}
 	module.write(entry)
 }
@@ -221,6 +219,12 @@ func (logger Logger) Warningf(message string, args ...interface{}) {
 // Infof logs the printf-formatted message at info level.
 func (logger Logger) Infof(message string, args ...interface{}) {
 	logger.Logf(INFO, message, args...)
+}
+
+// InfoWithLabelsf logs the printf-formatted message at info level with extra
+// labels.
+func (logger Logger) InfoWithLabelsf(message string, extraLabels map[string]string, args ...interface{}) {
+	logger.LogWithLabelsf(INFO, message, extraLabels, args...)
 }
 
 // Debugf logs the printf-formatted message at debug level.

--- a/logger_test.go
+++ b/logger_test.go
@@ -108,6 +108,35 @@ func (s *LoggerSuite) TestLogWithExtraLabels(c *gc.C) {
 		"domain": "status", "id": "0", "kind": "machine", "value": "idle"})
 }
 
+func (s *LoggerSuite) TestInfoWithLabelsf(c *gc.C) {
+	writer := &loggo.TestWriter{}
+	context := loggo.NewContext(loggo.INFO)
+	err := context.AddWriter("test", writer)
+	c.Assert(err, gc.IsNil)
+
+	logger := context.GetLogger("testing")
+	logger.SetLogLevel(loggo.INFO)
+	c.Assert(logger.LogLevel(), gc.Equals, loggo.INFO)
+
+	logger.InfoWithLabelsf("no extra labels", nil)
+	logger.InfoWithLabelsf("with extra labels", map[string]string{
+		"domain": "status",
+		"kind":   "machine",
+		"id":     "0",
+		"value":  "idle",
+	})
+
+	logs := writer.Log()
+	c.Assert(logs, gc.HasLen, 2)
+	c.Check(logs[0].Message, gc.Equals, "no extra labels")
+	c.Check(logs[0].Labels, gc.HasLen, 0)
+	c.Check(logs[0].Level, gc.Equals, loggo.INFO)
+	c.Check(logs[1].Message, gc.Equals, "with extra labels")
+	c.Check(logs[1].Labels, gc.DeepEquals, loggo.Labels{
+		"domain": "status", "id": "0", "kind": "machine", "value": "idle"})
+	c.Check(logs[1].Level, gc.Equals, loggo.INFO)
+}
+
 func (s *LoggerSuite) TestSetLevel(c *gc.C) {
 	logger := loggo.GetLogger("testing")
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -57,6 +57,32 @@ func (s *LoggerSuite) TestWithLabels(c *gc.C) {
 	})
 }
 
+func (s *LoggerSuite) TestLogWithExtraLabels(c *gc.C) {
+	writer := &loggo.TestWriter{}
+	context := loggo.NewContext(loggo.INFO)
+	err := context.AddWriter("test", writer)
+	c.Assert(err, gc.IsNil)
+
+	logger := context.GetLogger("testing")
+
+	logger.LogWithLabelsf(loggo.INFO, "no extra labels", nil)
+	logger.LogWithLabelsf(loggo.INFO, "with extra labels", map[string]string{
+		"domain": "status",
+		"kind":   "machine",
+		"id":     "0",
+		"value":  "idle",
+	})
+
+	logs := writer.Log()
+	c.Assert(logs, gc.HasLen, 2)
+	c.Check(logs[0].Message, gc.Equals, "no extra labels")
+	c.Check(logs[0].Labels, gc.HasLen, 0)
+	c.Check(logs[1].Message, gc.Equals, "with extra labels")
+	c.Check(logs[1].Labels, gc.DeepEquals, loggo.Labels{
+		"domain": "status", "id": "0", "kind": "machine", "value": "idle"})
+
+}
+
 func (s *LoggerSuite) TestSetLevel(c *gc.C) {
 	logger := loggo.GetLogger("testing")
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -57,6 +57,32 @@ func (s *LoggerSuite) TestWithLabels(c *gc.C) {
 	})
 }
 
+func (s *LoggerSuite) TestLogWithStaticAndDynamicLabels(c *gc.C) {
+	writer := &loggo.TestWriter{}
+	context := loggo.NewContext(loggo.INFO)
+	err := context.AddWriter("test", writer)
+	c.Assert(err, gc.IsNil)
+
+	logger := context.GetLogger("testing")
+	loggerWithLabels := logger.WithLabels(loggo.Labels{"foo": "bar"})
+
+	loggerWithLabels.LogWithLabelsf(loggo.INFO, "no extra labels", nil)
+	loggerWithLabels.LogWithLabelsf(loggo.INFO, "with extra labels", map[string]string{
+		"domain": "status",
+		"kind":   "machine",
+		"id":     "0",
+		"value":  "idle",
+	})
+
+	logs := writer.Log()
+	c.Assert(logs, gc.HasLen, 2)
+	c.Check(logs[0].Message, gc.Equals, "no extra labels")
+	c.Check(logs[0].Labels, gc.DeepEquals, loggo.Labels{"foo": "bar"})
+	c.Check(logs[1].Message, gc.Equals, "with extra labels")
+	c.Check(logs[1].Labels, gc.DeepEquals, loggo.Labels{
+		"foo": "bar", "domain": "status", "id": "0", "kind": "machine", "value": "idle"})
+}
+
 func (s *LoggerSuite) TestLogWithExtraLabels(c *gc.C) {
 	writer := &loggo.TestWriter{}
 	context := loggo.NewContext(loggo.INFO)
@@ -80,7 +106,6 @@ func (s *LoggerSuite) TestLogWithExtraLabels(c *gc.C) {
 	c.Check(logs[1].Message, gc.Equals, "with extra labels")
 	c.Check(logs[1].Labels, gc.DeepEquals, loggo.Labels{
 		"domain": "status", "id": "0", "kind": "machine", "value": "idle"})
-
 }
 
 func (s *LoggerSuite) TestSetLevel(c *gc.C) {


### PR DESCRIPTION
This adds the function `LogWithLabelsf` that's like the `LogCallf`, but takes an additional parameter `extraLabels map[string]string` to inject some key value pairs into the `entry.Labels`. This is useful because with this the labels don't need to be statically defined on the logger (e.g. `WithLabels`), but dynamically provided as arguments to each entry.

#### QA Steps

```
go test -gocheck.v -gocheck.f LoggerSuite
```

#### Links

JUJU-5552
