### PR TITLE
Inherited labels

### DIFF
--- a/config.go
+++ b/config.go
@@ -47,19 +47,19 @@ func parseConfigValue(value string) (string, Level, error) {
 		return "", UNSPECIFIED, fmt.Errorf("config value %q has missing module name", value)
 	}
 
-	if label := extractConfigLabel(name); label != "" {
-		if strings.Contains(label, ".") {
+	if tag := extractConfigTag(name); tag != "" {
+		if strings.Contains(tag, ".") {
 			// Show the original name and not text potentially extracted config
-			// label.
-			return "", UNSPECIFIED, fmt.Errorf("config label should not contain '.', found %q", name)
+			// tag.
+			return "", UNSPECIFIED, fmt.Errorf("config tag should not contain '.', found %q", name)
 		}
 		// Ensure once the normalised extraction has happened, we put the prefix
-		// back on, so that we don't loose the fact that the config is a label.
+		// back on, so that we don't loose the fact that the config is a tag.
 		//
 		// Ideally we would change Config from map[string]Level to
 		// map[string]ConfigEntry and then we wouldn't need this step, but that
 		// causes lots of issues in Juju directly.
-		name = fmt.Sprintf("#%s", label)
+		name = fmt.Sprintf("#%s", tag)
 	}
 
 	levelStr := strings.TrimSpace(pair[1])
@@ -87,8 +87,9 @@ func parseConfigValue(value string) (string, Level, error) {
 // so "DEBUG" is equivalent to `<root>=DEBUG`
 //
 // An example specification:
+//
 //	`<root>=ERROR; foo.bar=WARNING`
-//	`[LABEL]=ERROR`
+//	`[TAG]=ERROR`
 func ParseConfigString(specification string) (Config, error) {
 	specification = strings.TrimSpace(specification)
 	if specification == "" {
@@ -111,7 +112,7 @@ func ParseConfigString(specification string) (Config, error) {
 	return cfg, nil
 }
 
-func extractConfigLabel(s string) string {
+func extractConfigTag(s string) string {
 	name := strings.TrimSpace(s)
 	if len(s) < 2 {
 		return ""

--- a/config_test.go
+++ b/config_test.go
@@ -38,16 +38,16 @@ func (*ConfigSuite) TestParseConfigValue(c *gc.C) {
 		module: "",
 		level:  INFO,
 	}, {
-		value:  "#label = info",
-		module: "#label",
+		value:  "#tag = info",
+		module: "#tag",
 		level:  INFO,
 	}, {
-		value:  "#LABEL = info",
-		module: "#label",
+		value:  "#TAG = info",
+		module: "#tag",
 		level:  INFO,
 	}, {
-		value: "#label.1 = info",
-		err:   `config label should not contain '.', found "#label.1"`,
+		value: "#tag.1 = info",
+		err:   `config tag should not contain '.', found "#tag.1"`,
 	}} {
 		c.Logf("%d: %s", i, test.value)
 		module, level, err := parseConfigValue(test.value)

--- a/context.go
+++ b/context.go
@@ -112,6 +112,15 @@ func (c *Context) getLoggerModule(name string, tags []string) *module {
 			level = configLevel
 		}
 	}
+
+	// As it's not possible to modify the parent's labels, it's safe to copy
+	// them at the time of creation. Otherwise we have to walk the parent chain
+	// to get the full set of labels for every log message.
+	labels := make(Labels)
+	for k, v := range parent.labels {
+		labels[k] = v
+	}
+
 	impl = &module{
 		name:       name,
 		level:      level,
@@ -119,6 +128,7 @@ func (c *Context) getLoggerModule(name string, tags []string) *module {
 		context:    c,
 		tags:       tags,
 		tagsLookup: labelMap,
+		labels:     parent.labels,
 	}
 	c.modules[name] = impl
 	return impl

--- a/context.go
+++ b/context.go
@@ -17,9 +17,9 @@ type Context struct {
 
 	// Perhaps have one mutex?
 	// All `modules` variables are managed by the one mutex.
-	modulesMutex       sync.Mutex
-	modules            map[string]*module
-	modulesLabelConfig map[string]Level
+	modulesMutex     sync.Mutex
+	modules          map[string]*module
+	modulesTagConfig map[string]Level
 
 	writersMutex sync.Mutex
 	writers      map[string]Writer
@@ -35,9 +35,9 @@ func NewContext(rootLevel Level) *Context {
 		rootLevel = WARNING
 	}
 	context := &Context{
-		modules:            make(map[string]*module),
-		modulesLabelConfig: make(map[string]Level),
-		writers:            make(map[string]Writer),
+		modules:          make(map[string]*module),
+		modulesTagConfig: make(map[string]Level),
+		writers:          make(map[string]Writer),
 	}
 	context.root = &module{
 		level:   rootLevel,
@@ -50,26 +50,26 @@ func NewContext(rootLevel Level) *Context {
 
 // GetLogger returns a Logger for the given module name, creating it and
 // its parents if necessary.
-func (c *Context) GetLogger(name string, labels ...string) Logger {
+func (c *Context) GetLogger(name string, tags ...string) Logger {
 	name = strings.TrimSpace(strings.ToLower(name))
 
 	c.modulesMutex.Lock()
 	defer c.modulesMutex.Unlock()
 
 	return Logger{
-		impl: c.getLoggerModule(name, labels),
+		impl: c.getLoggerModule(name, tags),
 	}
 }
 
-// GetAllLoggerLabels returns all the logger labels for a given context. The
+// GetAllLoggerTags returns all the logger tags for a given context. The
 // names are unique and sorted before returned, to improve consistency.
-func (c *Context) GetAllLoggerLabels() []string {
+func (c *Context) GetAllLoggerTags() []string {
 	c.modulesMutex.Lock()
 	defer c.modulesMutex.Unlock()
 
 	names := make(map[string]struct{})
 	for _, module := range c.modules {
-		for k, v := range module.labelsLookup {
+		for k, v := range module.tagsLookup {
 			names[k] = v
 		}
 	}
@@ -108,17 +108,17 @@ func (c *Context) getLoggerModule(name string, tags []string) *module {
 		// First tag wins when setting the logger tag from the config tag
 		// level cache. If there are no tag configs, then fallback to
 		// UNSPECIFIED and inherit the level correctly.
-		if configLevel, ok := c.modulesLabelConfig[tag]; ok && level == UNSPECIFIED {
+		if configLevel, ok := c.modulesTagConfig[tag]; ok && level == UNSPECIFIED {
 			level = configLevel
 		}
 	}
 	impl = &module{
-		name:         name,
-		level:        level,
-		parent:       parent,
-		context:      c,
-		tags:         tags,
-		labelsLookup: labelMap,
+		name:       name,
+		level:      level,
+		parent:     parent,
+		context:    c,
+		tags:       tags,
+		tagsLookup: labelMap,
 	}
 	c.modules[name] = impl
 	return impl
@@ -132,7 +132,7 @@ func (c *Context) getLoggerModulesByTag(label string) []*module {
 			continue
 		}
 
-		if _, ok := mod.labelsLookup[label]; ok {
+		if _, ok := mod.tagsLookup[label]; ok {
 			modules = append(modules, mod)
 		}
 	}
@@ -172,18 +172,18 @@ func (c *Context) ApplyConfig(config Config) {
 	c.modulesMutex.Lock()
 	defer c.modulesMutex.Unlock()
 	for name, level := range config {
-		label := extractConfigLabel(name)
-		if label == "" {
+		tag := extractConfigTag(name)
+		if tag == "" {
 			module := c.getLoggerModule(name, nil)
 			module.setLevel(level)
 			continue
 		}
 
 		// Ensure that we save the config for lazy loggers to pick up correctly.
-		c.modulesLabelConfig[label] = level
+		c.modulesTagConfig[tag] = level
 
-		// Config contains a named label, use that for selecting the loggers.
-		modules := c.getLoggerModulesByTag(label)
+		// Config contains a named tag, use that for selecting the loggers.
+		modules := c.getLoggerModulesByTag(tag)
 		for _, module := range modules {
 			module.setLevel(level)
 		}
@@ -200,7 +200,7 @@ func (c *Context) ResetLoggerLevels() {
 		module.setLevel(UNSPECIFIED)
 	}
 	// We can safely just wipe everything here.
-	c.modulesLabelConfig = make(map[string]Level)
+	c.modulesTagConfig = make(map[string]Level)
 }
 
 func (c *Context) write(entry Entry) {

--- a/context_test.go
+++ b/context_test.go
@@ -216,25 +216,25 @@ func (*ContextSuite) TestApplyConfigAdditive(c *gc.C) {
 		})
 }
 
-func (*ContextSuite) TestGetAllLoggerLabels(c *gc.C) {
+func (*ContextSuite) TestGetAllLoggerTags(c *gc.C) {
 	context := loggo.NewContext(loggo.WARNING)
 	context.GetLogger("a.b", "one")
 	context.GetLogger("c.d", "one")
 	context.GetLogger("e", "two")
 
-	labels := context.GetAllLoggerLabels()
+	labels := context.GetAllLoggerTags()
 	c.Assert(labels, gc.DeepEquals, []string{"one", "two"})
 }
 
-func (*ContextSuite) TestGetAllLoggerLabelsWithApplyConfig(c *gc.C) {
+func (*ContextSuite) TestGetAllLoggerTagsWithApplyConfig(c *gc.C) {
 	context := loggo.NewContext(loggo.WARNING)
 	context.ApplyConfig(loggo.Config{"#one": loggo.TRACE})
 
-	labels := context.GetAllLoggerLabels()
+	labels := context.GetAllLoggerTags()
 	c.Assert(labels, gc.DeepEquals, []string{})
 }
 
-func (*ContextSuite) TestApplyConfigLabels(c *gc.C) {
+func (*ContextSuite) TestApplyConfigTags(c *gc.C) {
 	context := loggo.NewContext(loggo.WARNING)
 	context.GetLogger("a.b", "one")
 	context.GetLogger("c.d", "one")
@@ -339,7 +339,7 @@ func (*ContextSuite) TestApplyConfigLabelsResetLoggerLevels(c *gc.C) {
 		})
 }
 
-func (*ContextSuite) TestApplyConfigLabelsAddative(c *gc.C) {
+func (*ContextSuite) TestApplyConfigTagsAddative(c *gc.C) {
 	context := loggo.NewContext(loggo.WARNING)
 	context.ApplyConfig(loggo.Config{"#one": loggo.TRACE})
 	context.ApplyConfig(loggo.Config{"#two": loggo.DEBUG})
@@ -353,7 +353,7 @@ func (*ContextSuite) TestApplyConfigLabelsAddative(c *gc.C) {
 		})
 }
 
-func (*ContextSuite) TestApplyConfigWithMalformedLabel(c *gc.C) {
+func (*ContextSuite) TestApplyConfigWithMalformedTag(c *gc.C) {
 	context := loggo.NewContext(loggo.WARNING)
 	context.GetLogger("a.b", "one")
 
@@ -371,7 +371,7 @@ func (*ContextSuite) TestApplyConfigWithMalformedLabel(c *gc.C) {
 		})
 }
 
-func (*ContextSuite) TestResetLoggerLevels(c *gc.C) {
+func (*ContextSuite) TestResetLoggerTags(c *gc.C) {
 	context := loggo.NewContext(loggo.DEBUG)
 	context.ApplyConfig(loggo.Config{"first.second": loggo.TRACE})
 	context.ResetLoggerLevels()

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -1,5 +1,0 @@
-github.com/juju/ansiterm	git	720a0952cc2ac777afc295d9861263e2a4cf96a1	2018-01-09T21:29:12Z
-github.com/lunixbochs/vtclean	git	4fbf7632a2c6d3fbdb9931439bdbbeded02cbe36	2016-01-25T03:51:06Z
-github.com/mattn/go-colorable	git	ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8	2016-07-31T23:54:17Z
-github.com/mattn/go-isatty	git	66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8	2016-08-06T12:27:52Z
-gopkg.in/check.v1	git	4f90aeace3a26ad7021961c297b22c42160c7b25	2016-01-05T16:49:36Z

--- a/logger_test.go
+++ b/logger_test.go
@@ -290,13 +290,13 @@ func (s *LoggerSuite) TestChildSameContext(c *gc.C) {
 	c.Check(b, gc.Not(gc.DeepEquals), loggo.GetLogger("a.b"))
 }
 
-func (s *LoggerSuite) TestChildSameContextWithLabels(c *gc.C) {
+func (s *LoggerSuite) TestChildSameContextWithTags(c *gc.C) {
 	ctx := loggo.NewContext(loggo.DEBUG)
 
 	logger := ctx.GetLogger("a", "parent")
 	b := logger.ChildWithTags("b", "child")
 
-	c.Check(ctx.GetAllLoggerLabels(), gc.DeepEquals, []string{"child", "parent"})
+	c.Check(ctx.GetAllLoggerTags(), gc.DeepEquals, []string{"child", "parent"})
 	c.Check(logger.Tags(), gc.DeepEquals, []string{"parent"})
 	c.Check(b.Tags(), gc.DeepEquals, []string{"child"})
 }

--- a/module.go
+++ b/module.go
@@ -14,8 +14,8 @@ type module struct {
 	parent  *module
 	context *Context
 
-	tags         []string
-	labelsLookup map[string]struct{}
+	tags       []string
+	tagsLookup map[string]struct{}
 }
 
 // Name returns the module's name.

--- a/module.go
+++ b/module.go
@@ -16,6 +16,8 @@ type module struct {
 
 	tags       []string
 	tagsLookup map[string]struct{}
+
+	labels Labels
 }
 
 // Name returns the module's name.


### PR DESCRIPTION
This introduces the ability to inherit log labels. Prior to this
patch, loggers only allowed labels for the scoped leaf node of
a logger. Any child leaf nodes did not have the ability to know the
parent label.

In a similar vein to tags, we add labels to the module. This then
allows us to look up the parent on the forking of the child logger. As
there is no way to edit the labels of a module it's safe to clone
those labels at forking time. This removes the need to walk the
parent stack when attempting to log a value.