### PR TITLE
Customise the call depth

### DIFF
--- a/context.go
+++ b/context.go
@@ -57,7 +57,8 @@ func (c *Context) GetLogger(name string, tags ...string) Logger {
 	defer c.modulesMutex.Unlock()
 
 	return Logger{
-		impl: c.getLoggerModule(name, tags),
+		impl:      c.getLoggerModule(name, tags),
+		callDepth: defaultCallDepth,
 	}
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -18,7 +18,7 @@ func (*LoggerSuite) SetUpTest(c *gc.C) {
 }
 
 func (s *LoggerSuite) TestRootLogger(c *gc.C) {
-	root := loggo.Logger{}
+	root := loggo.Logger{}.WithCallDepth(2)
 	c.Check(root.Name(), gc.Equals, "<root>")
 	c.Check(root.LogLevel(), gc.Equals, loggo.WARNING)
 	c.Check(root.IsErrorEnabled(), gc.Equals, true)


### PR DESCRIPTION
If we wrap the logger call in another type, then when we call logger methods, the call depth will be off by 1. To fix this, we want to be able to state the call depth when constructing the logger.

This will ensure that the file names point to the right files for consistency reasons.

```
loggo.GetLogger("name").WithCallDepth(3)
```