### PR TITLE
Prevent module panic

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -241,7 +241,7 @@ func (logger Logger) logCallf(calldepth int, level Level, message string, extraL
 	if len(module.tags) > 0 {
 		entry.Labels[LoggerTags] = strings.Join(module.tags, ",")
 	}
-	for k, v := range logger.impl.labels {
+	for k, v := range module.labels {
 		entry.Labels[k] = v
 	}
 	for k, v := range logger.labels {


### PR DESCRIPTION
If the module is empty then attempting to get the labels from it will cause a panic. This can happen if you create a non-initialized logger.

    var logger loggo.Logger

It only happens in tests, and the intention is to just write those logs to /dev/null. Either way we should be backwards compatible with the logger setup and prevent the panic.