### PR TITLE
feat: add Helper method and function to log correct callsite location

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -13,10 +13,10 @@ var (
 	helpers     map[uintptr]struct{}
 )
 
-// Helper marks the caller as a helper function and will skip it when capturing
-// the callsite location.
-func Helper() {
-	helper(2)
+// Helper passed 1 marks the caller as a helper function and will skip it when
+// capturing the callsite location.
+func Helper(skip int) {
+	helper(skip + 1)
 }
 
 func helper(skip int) {

--- a/helper.go
+++ b/helper.go
@@ -1,0 +1,63 @@
+// Copyright 2025 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package loggo
+
+import (
+	"runtime"
+	"sync"
+)
+
+var (
+	helperMutex sync.RWMutex
+	helpers     map[uintptr]struct{}
+)
+
+// Helper marks the caller as a helper function and will skip it when capturing
+// the callsite location.
+func Helper() {
+	helper(2)
+}
+
+func helper(skip int) {
+	callers := [1]uintptr{}
+	if runtime.Callers(skip+2, callers[:]) == 0 {
+		panic("failed to get caller information")
+	}
+	pc := callers[0]
+	helperMutex.RLock()
+	if _, ok := helpers[pc]; ok {
+		helperMutex.RUnlock()
+		return
+	}
+	helperMutex.RUnlock()
+	helperMutex.Lock()
+	defer helperMutex.Unlock()
+	if helpers == nil {
+		helpers = make(map[uintptr]struct{})
+	}
+	helpers[pc] = struct{}{}
+}
+
+// caller behaves like runtime.Caller but skips functions marked by helper.
+func caller(skip int) (uintptr, string, int, bool) {
+	pc := [8]uintptr{}
+	n := runtime.Callers(skip+2, pc[:])
+	if n == 0 {
+		return 0, "", 0, false
+	}
+	helperMutex.RLock()
+	pcs := pc[:]
+	for i := n - 1; i >= 0; i-- {
+		if _, ok := helpers[pc[i]]; ok {
+			pcs = pc[i:]
+			break
+		}
+	}
+	helperMutex.RUnlock()
+	frames := runtime.CallersFrames(pcs)
+	if frame, ok := frames.Next(); ok {
+		return frame.PC, frame.File, frame.Line, true
+	}
+	return 0, "", 0, false
+}

--- a/logger.go
+++ b/logger.go
@@ -175,7 +175,11 @@ func (logger Logger) SetLogLevel(level Level) {
 // Note that the writers may also filter out messages that
 // are less than their registered minimum severity level.
 func (logger Logger) Logf(level Level, message string, args ...interface{}) {
-	logger.LogCallf(logger.callDepth, level, message, args...)
+	logger.logf(level, message, args...)
+}
+
+func (logger Logger) logf(level Level, message string, args ...interface{}) {
+	logger.logCallf(logger.callDepth, level, message, nil, args...)
 }
 
 // LogWithlabelsf logs a printf-formatted message at the given level with extra
@@ -184,7 +188,7 @@ func (logger Logger) Logf(level Level, message string, args ...interface{}) {
 // of the logger. Note that the writers may also filter out messages that are
 // less than their registered minimum severity level.
 func (logger Logger) LogWithLabelsf(level Level, message string, extraLabels map[string]string, args ...interface{}) {
-	logger.logCallf(logger.callDepth, level, message, extraLabels, args...)
+	logger.logCallf(logger.callDepth-1, level, message, extraLabels, args...)
 }
 
 // LogCallf logs a printf-formatted message at the given level.
@@ -195,7 +199,7 @@ func (logger Logger) LogWithLabelsf(level Level, message string, extraLabels map
 // Note that the writers may also filter out messages that
 // are less than their registered minimum severity level.
 func (logger Logger) LogCallf(calldepth int, level Level, message string, args ...interface{}) {
-	logger.logCallf(calldepth+1, level, message, nil, args...)
+	logger.logCallf(calldepth, level, message, nil, args...)
 }
 
 // logCallf is a private method for logging a printf-formatted message at the
@@ -255,38 +259,38 @@ func (logger Logger) logCallf(calldepth int, level Level, message string, extraL
 
 // Criticalf logs the printf-formatted message at critical level.
 func (logger Logger) Criticalf(message string, args ...interface{}) {
-	logger.Logf(CRITICAL, message, args...)
+	logger.logf(CRITICAL, message, args...)
 }
 
 // Errorf logs the printf-formatted message at error level.
 func (logger Logger) Errorf(message string, args ...interface{}) {
-	logger.Logf(ERROR, message, args...)
+	logger.logf(ERROR, message, args...)
 }
 
 // Warningf logs the printf-formatted message at warning level.
 func (logger Logger) Warningf(message string, args ...interface{}) {
-	logger.Logf(WARNING, message, args...)
+	logger.logf(WARNING, message, args...)
 }
 
 // Infof logs the printf-formatted message at info level.
 func (logger Logger) Infof(message string, args ...interface{}) {
-	logger.Logf(INFO, message, args...)
+	logger.logf(INFO, message, args...)
 }
 
 // InfoWithLabelsf logs the printf-formatted message at info level with extra
 // labels.
 func (logger Logger) InfoWithLabelsf(message string, extraLabels map[string]string, args ...interface{}) {
-	logger.LogWithLabelsf(INFO, message, extraLabels, args...)
+	logger.logCallf(logger.callDepth, INFO, message, extraLabels, args...)
 }
 
 // Debugf logs the printf-formatted message at debug level.
 func (logger Logger) Debugf(message string, args ...interface{}) {
-	logger.Logf(DEBUG, message, args...)
+	logger.logf(DEBUG, message, args...)
 }
 
 // Tracef logs the printf-formatted message at trace level.
 func (logger Logger) Tracef(message string, args ...interface{}) {
-	logger.Logf(TRACE, message, args...)
+	logger.logf(TRACE, message, args...)
 }
 
 // IsLevelEnabled returns whether debugging is enabled

--- a/logger.go
+++ b/logger.go
@@ -5,7 +5,6 @@ package loggo
 
 import (
 	"fmt"
-	"runtime"
 	"strings"
 	"time"
 )
@@ -210,7 +209,7 @@ func (logger Logger) logCallf(calldepth int, level Level, message string, extraL
 	now := time.Now() // get this early.
 	// Param to Caller is the call depth.  Since this method is called from
 	// the Logger methods, we want the place that those were called from.
-	_, file, line, ok := runtime.Caller(calldepth + 1)
+	_, file, line, ok := caller(calldepth + 1)
 	if !ok {
 		file = "???"
 		line = 0
@@ -324,4 +323,10 @@ func (logger Logger) IsDebugEnabled() bool {
 // at trace level.
 func (logger Logger) IsTraceEnabled() bool {
 	return logger.IsLevelEnabled(TRACE)
+}
+
+// Helper marks the caller as a helper function and will skip it when capturing
+// the callsite location.
+func (logger Logger) Helper() {
+	helper(2)
 }

--- a/logging_test.go
+++ b/logging_test.go
@@ -63,13 +63,16 @@ func (s *LoggingSuite) TestLoggingLimitWarning(c *gc.C) {
 }
 
 func (s *LoggingSuite) TestLocationCapture(c *gc.C) {
-	s.helperInfof(c, "helper message")     //tag helper-location
-	s.logger.Criticalf("critical message") //tag critical-location
-	s.logger.Errorf("error message")       //tag error-location
-	s.logger.Warningf("warning message")   //tag warning-location
-	s.logger.Infof("info message")         //tag info-location
-	s.logger.Debugf("debug message")       //tag debug-location
-	s.logger.Tracef("trace message")       //tag trace-location
+	s.helperInfof(c, "helper message")                             //tag helper-location
+	s.logger.Criticalf("critical message")                         //tag critical-location
+	s.logger.Errorf("error message")                               //tag error-location
+	s.logger.Warningf("warning message")                           //tag warning-location
+	s.logger.Infof("info message")                                 //tag info-location
+	s.logger.Debugf("debug message")                               //tag debug-location
+	s.logger.Tracef("trace message")                               //tag trace-location
+	s.logger.Logf(loggo.INFO, "logf msg")                          //tag logf-location
+	s.logger.LogCallf(1, loggo.INFO, "logcallf msg")               //tag logcallf-location
+	s.logger.LogWithLabelsf(loggo.INFO, "logwithlabelsf msg", nil) //tag logwithlabelsf-location
 
 	log := s.writer.Log()
 	tags := []string{
@@ -80,6 +83,9 @@ func (s *LoggingSuite) TestLocationCapture(c *gc.C) {
 		"info-location",
 		"debug-location",
 		"trace-location",
+		"logf-location",
+		"logcallf-location",
+		"logwithlabelsf-location",
 	}
 	c.Assert(log, gc.HasLen, len(tags))
 	for x := range tags {

--- a/logging_test.go
+++ b/logging_test.go
@@ -63,6 +63,7 @@ func (s *LoggingSuite) TestLoggingLimitWarning(c *gc.C) {
 }
 
 func (s *LoggingSuite) TestLocationCapture(c *gc.C) {
+	s.helperInfof(c, "helper message")     //tag helper-location
 	s.logger.Criticalf("critical message") //tag critical-location
 	s.logger.Errorf("error message")       //tag error-location
 	s.logger.Warningf("warning message")   //tag warning-location
@@ -72,6 +73,7 @@ func (s *LoggingSuite) TestLocationCapture(c *gc.C) {
 
 	log := s.writer.Log()
 	tags := []string{
+		"helper-location",
 		"critical-location",
 		"error-location",
 		"warning-location",
@@ -83,6 +85,11 @@ func (s *LoggingSuite) TestLocationCapture(c *gc.C) {
 	for x := range tags {
 		assertLocation(c, log[x], tags[x])
 	}
+}
+
+func (s *LoggingSuite) helperInfof(c *gc.C, format string, args ...any) {
+	s.logger.Helper()
+	s.logger.Infof(format, args...)
 }
 
 func (s *LoggingSuite) TestLogDoesntLogWeirdLevels(c *gc.C) {

--- a/util_test.go
+++ b/util_test.go
@@ -20,8 +20,9 @@ func init() {
 
 func assertLocation(c *gc.C, msg loggo.Entry, tag string) {
 	loc := location(tag)
-	c.Assert(msg.Filename, gc.Equals, loc.file)
-	c.Assert(msg.Line, gc.Equals, loc.line)
+	c.Check(fmt.Sprintf("%s:%d", msg.Filename, msg.Line), gc.Equals,
+		fmt.Sprintf("%s:%d", loc.file, loc.line),
+		gc.Commentf("tag=%s", tag))
 }
 
 // All this location stuff is to avoid having hard coded line numbers


### PR DESCRIPTION
This adds a Helper to ensure that locations of logs mark the correct
source file name and line number.